### PR TITLE
add fix used by the vis editor for long perl patterns

### DIFF
--- a/lexers/perl.lua
+++ b/lexers/perl.lua
@@ -75,6 +75,9 @@ local literal_delimited2 = P(function(input, index) -- for 2 delimiter sets
       patt = lexer.range(delimiter)
     end
     first_match_pos = lpeg.match(patt, input, index)
+    if not first_match_pos then
+      return #input + 1
+    end
     final_match_pos = lpeg.match(patt, input, first_match_pos - 1)
     if not final_match_pos then -- using (), [], {}, or <> notation
       final_match_pos = lpeg.match(lexer.space^0 * patt, input, first_match_pos)


### PR DESCRIPTION
The perl lexer used in the vis editor has a fix to deal with a regex pattern longer than a screen as introduced by the following [commit](https://github.com/martanne/vis/commit/9308e373844377f0db1f4f0d24d963dbd67c63ba#diff-722779ef27de1932aa121221480a4efd6c4a86d1067ca95c7ceaf43c9502d703)

To be able to bring the lexers back in sync it would be great if this fix could be merged.