### PR TITLE
Add asm lexer fix used by the vis editor

### DIFF
--- a/lexers/asm.lua
+++ b/lexers/asm.lua
@@ -68,7 +68,14 @@ lex:add_rule('instruction', token('instruction', word_match[[
   scasq scasw sfence sgdt shl shld shr shrd sidt sldt skinit smi smint smintold
   smsw stc std sti stosb stosd stosq stosw str sub svdc svldt svts swapgs
   syscall sysenter sysexit sysret test ud0 ud1 ud2b ud2 ud2a umov verr verw
-  fwait wbinvd wrshr wrmsr xadd xbts xchg xlatb xlat xor cmovcc jcc setcc
+  fwait wbinvd wrshr wrmsr xadd xbts xchg xlatb xlat xor xor cmova cmovae cmovb
+  cmovbe cmovc cmove cmovg cmovge cmovl cmovle cmovna cmovnae cmovnb cmovnbe
+  cmovnc cmovne cmovng cmovnge cmovnl cmovnle cmovno cmovnp cmovns cmovnz cmovo
+  cmovp cmovpe cmovpo cmovs cmovz cmovcc ja jae jb jbe jc je jg jge jl jle jna
+  jnae jnb jnbe jnc jne jng jnge jnl jnle jno jnp jns jnz jo jp jpe jpo js jz
+  seta setae setb setbe setc sete setg setge setl setle setna setnae setnb
+  setnbe setnc setne setng setnge setnl setnle setno setnp setns setnz seto
+  setp setpe setpo sets setz
   -- Katmai Streaming SIMD instructions (SSE -- a.k.a. KNI XMM MMX2).
   addps addss andnps andps cmpeqps cmpeqss cmpleps cmpless cmpltps cmpltss
   cmpneqps cmpneqss cmpnleps cmpnless cmpnltps cmpnltss cmpordps cmpordss


### PR DESCRIPTION
The vis editor has a commit that adds additional instructions for the asm.lua lexer, see this [this commit](https://github.com/martanne/vis/commit/e31b1e097de7530491bc85131c445a1ffccacdbf#diff-61d949ee345501e475a735cf70e024cb2494e6dd19bba71a3682c2f6b62e30b9)

To be able to bring the lexers back in sync it would be great if this could be merged.