### PR TITLE
Add case keyword to rc lexer to match vis

### DIFF
--- a/lexers/rc.lua
+++ b/lexers/rc.lua
@@ -12,7 +12,7 @@ lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match[[
-  for in while if not switch fn builtin cd eval exec exit flag rfork shift
+  for in while if not switch case fn builtin cd eval exec exit flag rfork shift
   ulimit umask wait whatis . ~
 ]]))
 


### PR DESCRIPTION
The vis editor added the case keyword to the rc lexer in [this commit](https://github.com/martanne/vis/commit/97bfecaf908bbe2ae5ac87475c85cfba2fe5267f#diff-36b4b40fc374f8fb19f69b9f70dc2b6d5e0898393e6da1830d6ec23e56c2046c).

Adding this would enable to sync the lexers.