### PR TITLE
Add async/await keywords to javascript

### DIFF
--- a/lexers/javascript.lua
+++ b/lexers/javascript.lua
@@ -12,12 +12,12 @@ lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match[[
-  abstract boolean break byte case catch char class const continue debugger
-  default delete do double else enum export extends false final finally float
-  for function get goto if implements import in instanceof int interface let
-  long native new null of package private protected public return set short
-  static super switch synchronized this throw throws transient true try typeof
-  var void volatile while with yield
+  abstract async await boolean break byte case catch char class const continue
+  debugger default delete do double else enum export extends false final
+  finally float for function get goto if implements import in instanceof int
+  interface let long native new null of package private protected public return
+  set short static super switch synchronized this throw throws transient true
+  try typeof var void volatile while with yield
 ]]))
 
 -- Identifiers.


### PR DESCRIPTION
The vis editor added a commit adding async/await keywords to the javascript lexer in commit
36b573ad416f18e14f85d69cd5acf431b33fd48a 

This merges that change as a step towards bringing the lexers back in sync