### PR TITLE
Add fix for crash in rest lexer from vis

### DIFF
--- a/lexers/rest.lua
+++ b/lexers/rest.lua
@@ -28,7 +28,7 @@ local overline = lpeg.Cmt(starts_line(adornment), function(input, index, adm, c)
   return #input + 1
 end)
 local underline = lpeg.Cmt(starts_line(adornment), function(_, index, adm, c)
-  local pos = adm:match('^%' .. c .. '+()%s*$')
+  local pos = adm:match('^%' .. c .. '+%s*()$')
   return pos and index - #adm + pos - 1 or nil
 end)
 -- Token needs to be a predefined one in order for folder to work.


### PR DESCRIPTION
Vis commited a fix for a crash in the rest lexer in
352404dc442896029b01a0da6f9b29e39ec5c53c to address
https://github.com/martanne/vis/issues/665

It would be good if this could be merged to enable syncing