### PR TITLE
Add ruby lexer patches from vis not upstreamed

### DIFF
--- a/lexers/ruby.lua
+++ b/lexers/ruby.lua
@@ -20,10 +20,11 @@ lex:add_rule('keyword', token(lexer.KEYWORD, word_match[[
 -- Functions.
 lex:add_rule('function', token(lexer.FUNCTION, word_match[[
   at_exit autoload binding caller catch chop chop! chomp chomp! eval exec exit
-  exit! fail fork format gets global_variables gsub gsub! iterator? lambda load
-  local_variables loop open p print printf proc putc puts raise rand readline
-  readlines require select sleep split sprintf srand sub sub! syscall system
-  test trace_var trap untrace_var
+  exit! extend fail fork format gets global_variables gsub gsub! include
+  iterator? lambda load local_variables loop module_function open p print
+  printf proc putc puts raise rand readline readlines require require_relative
+  select sleep split sprintf srand sub sub! syscall system test trace_var trap
+  untrace_var
 ]]) * -S('.:|'))
 
 local word_char = lexer.alnum + S('_!?')
@@ -64,7 +65,7 @@ local dq_str = lexer.range('"')
 local lit_str = '%' * S('qQ')^-1 * literal_delimited
 local heredoc = '<<' * P(function(input, index)
   local s, e, indented, _, delimiter = input:find(
-    '(%-?)(["`]?)([%a_][%w_]*)%2[\n\r\f;]+', index)
+    '([%-~]?)(["`]?)([%a_][%w_]*)%2[\n\r\f;]+', index)
   if s == index and delimiter then
     local end_heredoc = (#indented > 0 and '[\n\r\f]+ *' or '[\n\r\f]+')
     local _, e = input:find(end_heredoc .. delimiter, e)


### PR DESCRIPTION
This adds patches that got merged in vis, but are not present in this upstream. This adds:

1) more keywords from commit 82646f1b541185e4cb1874f4df584104e63db3df

2) add squiggly heredocs from commit 8ecc5915690112a2ea02ee3a9d4c30c017f6bb98