### PR TITLE
Add fix for slow yaml lexer as in vis source

### DIFF
--- a/lexers/yaml.lua
+++ b/lexers/yaml.lua
@@ -65,11 +65,7 @@ local word = (lexer.alpha + '-' * -lexer.space) * (lexer.alnum + '-')^0
 
 -- Keys and literals.
 local colon = S(' \t')^0 * ':' * (lexer.space + -1)
-local key = token(lexer.KEYWORD, #word * (lexer.nonnewline - colon)^1 * #colon *
-  P(function(input, index)
-    local line = input:sub(1, index - 1):match('[^\r\n]+$')
-    return not line:find('[%w-]+:') and index
-  end))
+local key = token(l.KEYWORD, (l.alnum + '_' + '-')^1 * #(':' * l.space))
 local value = #word * (lexer.nonnewline - lexer.space^0 * S(',]}'))^1
 local block = S('|>') * S('+-')^-1 * (lexer.newline + -1) *
   function(input, index)


### PR DESCRIPTION
This adds a fix for "incorrect and slow yaml lexer" present in vis source as commit 79859b57fc3556c2ed74950a5a5668c64face4e3 that didn't get upstreamed.

See: [this commit](https://github.com/martanne/vis/commit/79859b57fc3556c2ed74950a5a5668c64face4e3#diff-1c0754c7810f4d45fcd1c6c8663f0edb69765675f147b6255c0a054c67de5a0d)