### PR TITLE
Add xml lexer performance improvement used in vis

### DIFF
--- a/lexers/xml.lua
+++ b/lexers/xml.lua
@@ -47,13 +47,7 @@ lex:add_rule('attribute', token('attribute', identifier) * namespace^-1 *
 lex:add_style('attribute', lexer.styles.type)
 
 -- TODO: performance is terrible on large files.
-local in_tag = P(function(input, index)
-  local before = input:sub(1, index - 1)
-  local s, e = before:find('<[^>]-$'), before:find('>[^<]-$')
-  if s and e then return s > e and index or nil end
-  if s then return index end
-  return input:find('^[^<]->', index) and index or nil
-end)
+local in_tag = #P((1 - S'><')^0 * '>')
 
 -- Equals.
 --lex:add_rule('equal', token(lexer.OPERATOR, '=')) -- * in_tag


### PR DESCRIPTION
This adds performance improvements for the xml lexer added to vis in commits: 7e9e0a2ca868aaa214fb38a79fe71da34d6e00da and
baa51e934ce057af5b5be829d6a73a3e8b4c03d0