### PR TITLE
add copyright statement to template

### DIFF
--- a/lexers/template.txt
+++ b/lexers/template.txt
@@ -1,3 +1,4 @@
+-- Copyright 2006-2020 Mitchell. See LICENSE.
 -- ? LPeg lexer.
 
 local lexer = require('lexer')


### PR DESCRIPTION
The current template lacks a copyright statement. My guess is that it is better to add a default statement that puts it under your name and the default license. Those that want to can then add their own line.

The attached file just add the default statement at the top.