### PR TITLE
Add whitespace detection to the text lexer

### DIFF
--- a/lexers/text.lua
+++ b/lexers/text.lua
@@ -1,4 +1,9 @@
 -- Copyright 2006-2020 Mitchell. See LICENSE.
 -- Text LPeg lexer.
+local lexer = require('lexer')
+local lex = lexer.new('text')
 
-return require('lexer').new('text')
+-- Whitespace
+lex:add_rule('whitespace', lexer.token(lexer.WHITESPACE, lexer.space^1))
+
+return lex


### PR DESCRIPTION
Vis has a commit 807ba6f6850bf7dbf86fd65299248f2d9cba7f75 to match whitespaces as explained [here](https://github.com/martanne/vis/commit/807ba6f6850bf7dbf86fd65299248f2d9cba7f75) 

Although I'm not a 100% sure why you would want to do this it is probably worth adding, which is what this pull request does. 