### PR TITLE
Update PHP keywords and constants as used in vis

### DIFF
--- a/lexers/php.lua
+++ b/lexers/php.lua
@@ -12,13 +12,40 @@ lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match[[
-  and array as bool boolean break case cfunction class const continue declare
-  default die directory do double echo else elseif empty enddeclare endfor
-  endforeach endif endswitch endwhile eval exit extends false float for foreach
-  function global if include include_once int integer isset list new null object
-  old_function or parent print real require require_once resource return static
-  stdclass string switch true unset use var while xor
-  __class__ __file__ __function__ __line__ __sleep __wakeup
+  -- http://php.net/manual/en/reserved.keywords.php
+  __halt_compiler abstract and array as break callable case catch class
+  clone const continue declare default die do echo else elseif empty
+  enddeclare endfor endforeach endif endswitch endwhile eval exit extends
+  final for foreach function global goto if implements include list namespace
+  new or print private protected public require require_once return
+  static switch throw trait try unset use var while xor
+  -- http://php.net/manual/en/reserved.classes.php
+  directory stdclass __php_incomplete_class exception errorexception
+  closure generator arithmeticerror assertionerror divisionbyzeroerror
+  error throwable parseerror typeerror self parent
+  -- http://php.net/manual/en/reserved.other-reserved-words.php
+  int float bool string true false null void iterable resource object
+  mixed numeric
+]]))
+
+-- Constants.
+lex:add_rule('constant', token(lexer.CONSTANT, word_match[[
+  -- Compile-time constants
+  -- http://php.net/manual/en/reserved.keywords.php
+  __CLASS__ __DIR__ __FILE__ __FUNCTION__ __LINE__ __METHOD__
+  __NAMESPACE__ __TRAIT__
+  -- http://php.net/manual/en/reserved.constants.php
+  PHP_VERSION PHP_MAJOR_VERSION PHP_MINOR_VERSION PHP_RELEASE_VERSION
+  PHP_VERSION_ID PHP_EXTRA_VERSION PHP_ZTS PHP_DEBUG PHP_MAXPATHLEN
+  PHP_OS PHP_OS_FAMILY PHP_SAPI PHP_EOL PHP_INT_MAX PHP_INT_MIN
+  PHP_INT_SIZE PHP_FLOAT_DIG PHP_FLOAT_EPSILON PHP_FLOAT_MIN PHP_FLOAT_MAX
+  DEFAULT_INCLUDE_PATH PEAR_INSTALL_DIR PEAR_EXTENSION_DIR PHP_EXTENSION_DIR
+  PHP_PREFIX PHP_BINDIR PHP_BINARY PHP_MANDIR PHP_LIBDIR PHP_DATADIR
+  PHP_SYSCONFDIR PHP_LOCALSTATEDIR PHP_CONFIG_FILE_PATH
+  PHP_CONFIG_FILE_SCAN_DIR PHP_SHLIB_SUFFIX PHP_FD_SETSIZE E_ERROR
+  E_WARNING E_PARSE E_NOTICE E_CORE_ERROR E_CORE_WARNING E_COMPILE_ERROR
+  E_USER_ERROR E_USER_WARNING E_USER_NOTICE E_DEPRECATED E_DEPRECATED
+  E_USER_DEPRECATED E_ALL E_STRICT __COMPILER_HALT_OFFSET__
 ]]))
 
 local word = (lexer.alpha + '_' + lpeg.R('\127\255')) *


### PR DESCRIPTION
This pull request merges commits from vis that add additional constants and keywords, see [here](https://github.com/martanne/vis/commit/c88474f1036b6f21ecdb477297c6a5fc27838c53#diff-1e6aaa20254c986f575c28edb926c32a26915357cadfaa557bedc5a25b3ef01d) and [here](https://github.com/martanne/vis/commit/3232697eeae7fd442b12404e72ad31e32e5ae08e#diff-1e6aaa20254c986f575c28edb926c32a26915357cadfaa557bedc5a25b3ef01d)

Note that there is also [this patch](https://github.com/martanne/vis/commit/0ff02a70f911327e8a1f92881f5ef43b7cd0e7c8#diff-1e6aaa20254c986f575c28edb926c32a26915357cadfaa557bedc5a25b3ef01d) that I haven't added, but that is worth a check.
