### PR TITLE
Makefile lexer updated to support multiple targets

### DIFF
--- a/lexers/makefile.lua
+++ b/lexers/makefile.lua
@@ -28,7 +28,8 @@ local special_target = token(lexer.CONSTANT, word_match{
   '.NOTPARALLEL', '.ONESHELL', '.POSIX'
 })
 local normal_target = token('target', (lexer.any - lexer.space - S(':#='))^1)
-lex:add_rule('target', lexer.starts_line((special_target + normal_target) * ws^0 * #(':' * -P('='))))
+local target_list = normal_target * (ws * normal_target)^0
+lex:add_rule('target', lexer.starts_line((special_target + target_list) * ws^0 * #(':' * -P('='))))
 lex:add_style('target', lexer.styles.label)
 
 -- Variables.


### PR DESCRIPTION
Patch adds support for multiple targets in a single rule as POSIX standard describes them. It does not introduce support for grouped targets as they are defined by GNU Make.

I'm propagating the same (pending) change from vis editor. It was checked against vis - I used it for at least half a year so far. However, it was not tested directly with scintillua, if you find it necessary, I can look into setting something up.