### PR TITLE
Fix Perl lexer number parsing

### DIFF
--- a/lexers/perl.lua
+++ b/lexers/perl.lua
@@ -121,7 +121,11 @@ local block_comment = lexer.range(lexer.starts_line('=' * lexer.alpha), lexer.st
 lex:add_rule('comment', token(lexer.COMMENT, block_comment + line_comment))
 
 -- Numbers.
-lex:add_rule('number', token(lexer.NUMBER, lexer.number))
+local dec = lexer.digit^1 * ("_" * lexer.digit^1)^0
+local hex = '0' * S('xX') * lexer.xdigit^1 * ("_" * lexer.xdigit^1)^0
+local bin = '0' * S('bB') * S('01')^1 * ("_" * S('01')^1)^0
+local integer = S('+-')^-1 * (hex + bin + dec)
+lex:add_rule('number', token(lexer.NUMBER, lexer.float + integer))
 
 -- Variables.
 -- LuaFormatter off


### PR DESCRIPTION
* Numbers can be preceeded by "0b", "0x" and "0"
* Numbers can be visually separated via "_"

See https://www.perltutorial.org/perl-numbers/ and https://perldoc.perl.org/perlnumber