### PR TITLE
Update fortran.lua

### DIFF
--- a/lexers/fortran.lua
+++ b/lexers/fortran.lua
@@ -16,21 +16,34 @@ lex:add_rule('comment', token(lexer.COMMENT, line_comment))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match({
-  'include', 'program', 'module', 'subroutine', 'function', 'contains', 'use', 'call', 'return',
+  'include', 'interface', 'program', 'module', 'subroutine', 'function', 'contains', 'use', 'call',
+  'return',
   -- Statements.
   'case', 'select', 'default', 'continue', 'cycle', 'do', 'while', 'else', 'if', 'elseif', 'then',
-  'elsewhere', 'end', 'endif', 'enddo', 'forall', 'where', 'exit', 'goto', 'pause', 'stop',
+  'elsewhere', 'end', 'endif', 'enddo', 'equivalence', 'external', 'forall', 'where', 'exit',
+  'goto', 'pause', 'save', 'stop',
   -- Operators.
   '.not.', '.and.', '.or.', '.xor.', '.eqv.', '.neqv.', '.eq.', '.ne.', '.gt.', '.ge.', '.lt.',
   '.le.',
   -- Logical.
-  '.false.', '.true.'
+  '.false.', '.true.',
+  -- Attributes and other keywords
+  'access', 'action', 'advance', 'assignment', 'block', 'entry',
+  'in', 'inout', 'intent', 'only', 'out', 'optional', 'pointer', 'precision', 'procedure',
+  'recursive', 'result', 'sequence', 'size', 'stat', 'target', 'type',
+  -- ISO C binding from Fortran 2003
+  'bind', 'c_int', 'c_short', 'c_long', 'c_long_long', 'c_signed_char', 'c_size_t', 'c_int8_t',
+  'c_int16_t', 'c_int32_t', 'c_int64_t', 'c_int128_t', 'c_intptr_t', 'c_float', 'c_double',
+  'c_long_double', 'c_float128', 'c_float_complex', 'c_double_complex', 'c_long_double_complex',
+  'c_float128_complex', 'c_bool', 'c_char', 'c_null_char', 'c_new_line', 'c_null_ptr',
+  'c_funptr'
 }, true)))
 
 -- Functions.
 lex:add_rule('function', token(lexer.FUNCTION, word_match({
   -- I/O.
-  'backspace', 'close', 'endfile', 'inquire', 'open', 'print', 'read', 'rewind', 'write', 'format',
+  'backspace', 'close', 'endfile', 'inquire', 'open', 'print', 'read', 'rewind',
+  'write', 'format',
   -- Type conversion utility and math.
   'aimag', 'aint', 'amax0', 'amin0', 'anint', 'ceiling', 'cmplx', 'conjg', 'dble', 'dcmplx',
   'dfloat', 'dim', 'dprod', 'float', 'floor', 'ifix', 'imag', 'int', 'logical', 'modulo', 'nint',
@@ -41,7 +54,13 @@ lex:add_rule('function', token(lexer.FUNCTION, word_match({
   'dmax1', 'dmin1', 'dmod', 'dnint', 'dprod', 'dreal', 'dsign', 'dsin', 'dsinh', 'dsqrt', 'dtan',
   'dtanh', 'exp', 'float', 'iabs', 'ichar', 'idim', 'idint', 'idnint', 'ifix', 'index', 'int',
   'isign', 'len', 'lge', 'lgt', 'lle', 'llt', 'log', 'log10', 'max', 'max0', 'max1', 'min', 'min0',
-  'min1', 'mod', 'nint', 'real', 'sign', 'sin', 'sinh', 'sngl', 'sqrt', 'tan', 'tanh'
+  'min1', 'mod', 'nint', 'real', 'sign', 'sin', 'sinh', 'sngl', 'sqrt', 'tan', 'tanh',
+  -- matrix math
+  'matmul', 'transpose', 'reshape', 
+  -- Other frequently used built-in statements
+  'assign', 'nullify',
+  -- ISO C binding from Fortran 2003
+  'c_sizeof', 'c_f_pointer', 'c_associated'
 }, true)))
 
 -- Types.


### PR DESCRIPTION
More Fortran 90+ keywords for modern Fortran. Not sure if this is appropriate but these does make my syntax highlighting much more natural/closer to Emacs' one in Fortran 90.