### PR TITLE
Add a lexer for .spec files used for creating RPM packages (Linux distros)

### DIFF
--- a/lexers/rpmspec.lua
+++ b/lexers/rpmspec.lua
@@ -18,11 +18,19 @@ lex:add_rule('comment', comment)
 local string = token(lexer.STRING, lexer.delimited_range('"'))
 lex:add_rule('string', string)
 
--- -- Keywords.
--- local keyword = token(lexer.KEYWORD, word_match({
---   ''
--- }, nil, true))
--- lex:add_rule('keyword', keyword)
+-- Keywords.
+local keyword = token(lexer.KEYWORD, word_match({
+  ''
+  'Prereq', 'Summary', 'Name', 'Version', 'Packager', 'Requires',
+  'Recommends', 'Suggests', 'Supplements', 'Enhances', 'Icon', 'URL',
+  'Source', 'Patch', 'Prefix', 'Packager', 'Group', 'License',
+  'Release', 'BuildRoot', 'Distribution', 'Vendor', 'Provides',
+  'ExclusiveArch', 'ExcludeArch', 'ExclusiveOS', 'Obsoletes',
+  'BuildArch', 'BuildArchitectures', 'BuildRequires', 'BuildConflicts',
+  'BuildPreReq', 'Conflicts', 'AutoRequires', 'AutoReq', 'AutoReqProv',
+  'AutoProv', 'Epoch'
+}, nil, true))
+lex:add_rule('keyword', keyword)
 
 -- Macros
 local command = token(lexer.FUNCTION, '%' * lexer.word)
@@ -35,14 +43,6 @@ lex:add_rule('command', command)
 
 -- Identifiers.
 local identifier = token(lexer.IDENTIFIER, word_match({
-  'Prereq', 'Summary', 'Name', 'Version', 'Packager', 'Requires',
-  'Recommends', 'Suggests', 'Supplements', 'Enhances', 'Icon', 'URL',
-  'Source', 'Patch', 'Prefix', 'Packager', 'Group', 'License',
-  'Release', 'BuildRoot', 'Distribution', 'Vendor', 'Provides',
-  'ExclusiveArch', 'ExcludeArch', 'ExclusiveOS', 'Obsoletes',
-  'BuildArch', 'BuildArchitectures', 'BuildRequires', 'BuildConflicts',
-  'BuildPreReq', 'Conflicts', 'AutoRequires', 'AutoReq', 'AutoReqProv',
-  'AutoProv', 'Epoch'
 }))
 lex:add_rule('identifier', identifier)
 

--- a/lexers/rpmspec.lua
+++ b/lexers/rpmspec.lua
@@ -1,0 +1,49 @@
+-- Copyright 2022 Matej Cepl mcepl.att.cepl.eu, MIT/X11 license
+
+local lexer = require('lexer')
+local token, word_match = lexer.token, lexer.word_match
+local P, R, S = lpeg.P, lpeg.R, lpeg.S
+
+local lex = lexer.new('rpmspec')
+
+-- Whitespace.
+local ws = token(lexer.WHITESPACE, lexer.space^1)
+lex:add_rule('whitespace', ws)
+
+-- Comments.
+local comment = token(lexer.COMMENT, lexer.to_eol('#'))
+lex:add_rule('comment', comment)
+
+-- Strings.
+local string = token(lexer.STRING, lexer.delimited_range('"'))
+lex:add_rule('string', string)
+
+-- -- Keywords.
+-- local keyword = token(lexer.KEYWORD, word_match({
+--   ''
+-- }, nil, true))
+-- lex:add_rule('keyword', keyword)
+
+-- Macros
+local command = token(lexer.FUNCTION, '%' * lexer.word)
+lex:add_rule('command', command)
+
+-- -- Constants.
+-- local constant = token(lexer.CONSTANT, word_match({
+-- }, nil, true))
+-- lex:add_rule('constant', constant)
+
+-- Identifiers.
+local identifier = token(lexer.IDENTIFIER, word_match({
+  'Prereq', 'Summary', 'Name', 'Version', 'Packager', 'Requires',
+  'Recommends', 'Suggests', 'Supplements', 'Enhances', 'Icon', 'URL',
+  'Source', 'Patch', 'Prefix', 'Packager', 'Group', 'License',
+  'Release', 'BuildRoot', 'Distribution', 'Vendor', 'Provides',
+  'ExclusiveArch', 'ExcludeArch', 'ExclusiveOS', 'Obsoletes',
+  'BuildArch', 'BuildArchitectures', 'BuildRequires', 'BuildConflicts',
+  'BuildPreReq', 'Conflicts', 'AutoRequires', 'AutoReq', 'AutoReqProv',
+  'AutoProv', 'Epoch'
+}))
+lex:add_rule('identifier', identifier)
+
+return lex


### PR DESCRIPTION
This is WIP still, I don’t know what’s wrong with it, but [vis](https://github.com/martanne/vis/) doesn’t show anything.