### PR TITLE
Update rpmspec lexer, to make it more useable.

### DIFF
--- a/lexers/rpmspec.lua
+++ b/lexers/rpmspec.lua
@@ -12,8 +12,8 @@ lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 -- Comments.
 lex:add_rule('comment', token(lexer.COMMENT, lexer.to_eol('#')))
 
--- Numbers (including versions)
-lex:add_rule('number', token(lexer.NUMBER, lexer.number + S('.+~')))
+-- -- Numbers (including versions)
+-- lex:add_rule('number', token(lexer.NUMBER, lexer.number + S('.+~')))
 
 -- Operators
 lex:add_rule('operator', token(lexer.OPERATOR, S('&<>=|')))

--- a/lexers/rpmspec.lua
+++ b/lexers/rpmspec.lua
@@ -16,7 +16,7 @@ lex:add_rule('comment', token(lexer.COMMENT, lexer.to_eol('#')))
 lex:add_rule('string', token(lexer.STRING, lexer.range('"')))
 
 -- Keywords.
-lex:add_rule('keyword', token(lexer.KEYWORD, word_match{
+lex:add_rule('keyword', token(lexer.KEYWORD, word_match({
     'Prereq', 'Summary', 'Name', 'Version', 'Packager',
     'Requires', 'Recommends', 'Suggests', 'Supplements',
     'Enhances', 'Icon', 'URL', 'Prefix', 'Packager', 'Group',
@@ -25,7 +25,7 @@ lex:add_rule('keyword', token(lexer.KEYWORD, word_match{
     'Obsoletes', 'BuildArch', 'BuildArchitectures', 'BuildRequires',
     'BuildConflicts', 'BuildPreReq', 'Conflicts', 'AutoRequires',
     'AutoReq', 'AutoReqProv', 'AutoProv', 'Epoch'
-}) + (P('Patch') + P('Source')) * R('09')^0)
+}) + (P('Patch') + P('Source')) * R('09')^0))
 
 -- Macros
 lex:add_rule('command', token(lexer.FUNCTION, '%' * lexer.word +

--- a/lexers/rpmspec.lua
+++ b/lexers/rpmspec.lua
@@ -12,6 +12,12 @@ lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 -- Comments.
 lex:add_rule('comment', token(lexer.COMMENT, lexer.to_eol('#')))
 
+-- Numbers (including versions)
+lex:add_rule('number', token(lexer.NUMBER, lexer.number + S('.+~')))
+
+-- Operators
+lex:add_rule('operator', token(lexer.OPERATOR, S('&<>=|')))
+
 -- Strings.
 lex:add_rule('string', token(lexer.STRING, lexer.range('"')))
 
@@ -28,12 +34,11 @@ lex:add_rule('keyword', token(lexer.KEYWORD, word_match({
 }) + (P('Patch') + P('Source')) * R('09')^0))
 
 -- Macros
-lex:add_rule('command', token(lexer.FUNCTION, '%' * lexer.word +
-                                              '%{' * lexer.word * '}'))
+lex:add_rule('command', token(lexer.FUNCTION, S('%$')^1 * S('{')^0 * lexer.word * S('}')^0 ))
 
 -- Constants
 lex:add_rule('constant', token(lexer.CONSTANT, word_match({
-    'rhel', 'fedora', 'suse_version', 'sle_version'
+    'rhel', 'fedora', 'suse_version', 'sle_version', 'x86_64'
 })))
 
 lexer.property['scintillua.comment'] = '#'

--- a/lexers/rpmspec.lua
+++ b/lexers/rpmspec.lua
@@ -2,7 +2,7 @@
 
 local lexer = require('lexer')
 local token, word_match = lexer.token, lexer.word_match
-local P, S = lpeg.P, lpeg.S
+local C, P, R, S = lpeg.C, lpeg.P, lpeg.R, lpeg.S
 
 local lex = lexer.new('rpmspec')
 
@@ -17,16 +17,24 @@ lex:add_rule('string', token(lexer.STRING, lexer.range('"')))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{
-  'Prereq', 'Summary', 'Name', 'Version', 'Packager', 'Requires', 'Recommends', 'Suggests',
-  'Supplements', 'Enhances', 'Icon', 'URL', 'Source', 'Patch', 'Prefix', 'Packager', 'Group',
-  'License', 'Release', 'BuildRoot', 'Distribution', 'Vendor', 'Provides', 'ExclusiveArch',
-  'ExcludeArch', 'ExclusiveOS', 'Obsoletes', 'BuildArch', 'BuildArchitectures', 'BuildRequires',
-  'BuildConflicts', 'BuildPreReq', 'Conflicts', 'AutoRequires', 'AutoReq', 'AutoReqProv',
-  'AutoProv', 'Epoch'
-}))
+    'Prereq', 'Summary', 'Name', 'Version', 'Packager',
+    'Requires', 'Recommends', 'Suggests', 'Supplements',
+    'Enhances', 'Icon', 'URL', 'Prefix', 'Packager', 'Group',
+    'License', 'Release', 'BuildRoot', 'Distribution', 'Vendor',
+    'Provides', 'ExclusiveArch', 'ExcludeArch', 'ExclusiveOS',
+    'Obsoletes', 'BuildArch', 'BuildArchitectures', 'BuildRequires',
+    'BuildConflicts', 'BuildPreReq', 'Conflicts', 'AutoRequires',
+    'AutoReq', 'AutoReqProv', 'AutoProv', 'Epoch'
+}) + (P('Patch') + P('Source')) * R('09')^0)
 
 -- Macros
-lex:add_rule('command', token(lexer.FUNCTION, '%' * lexer.word))
+lex:add_rule('command', token(lexer.FUNCTION, '%' * lexer.word +
+                                              '%{' * lexer.word * '}'))
+
+-- Constants
+lex:add_rule('constant', token(lexer.CONSTANT, word_match({
+    'rhel', 'fedora', 'suse_version', 'sle_version'
+})))
 
 lexer.property['scintillua.comment'] = '#'
 


### PR DESCRIPTION
Unfortunately, this is not working, and I would like to ask for help why.

All these lines should be marked as keywords, but they are not:
```spec
Source: source.tar.gz
Source0: anothersource.tar.gz
Patch:  first.patch
Patch0: second.patch
```