### PR TITLE
Add modern rewrite of strace lexer from vis.

### DIFF
--- a/lexers/strace.lua
+++ b/lexers/strace.lua
@@ -1,0 +1,35 @@
+-- Copyright 2017-2021 Marc André Tanner. See LICENSE.
+-- strace(1) output lexer
+
+local lexer = require('lexer')
+local token, word_match = lexer.token, lexer.word_match
+local S, B = lpeg.S, lpeg.B
+
+local lex = lexer.new('strace', {lex_by_line = true})
+
+-- Whitespace
+lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+
+-- Syscall
+lex:add_rule('syscall', token(lexer.KEYWORD, lexer.starts_line(lexer.word)))
+
+-- Upper case constants
+lex:add_rule('constant', token(lexer.CONSTANT,
+  (lexer.upper + '_') * (lexer.upper + lexer.digit + '_')^0))
+
+-- Single and double quoted strings
+local sq_str = lexer.range("'", true)
+local dq_str = lexer.range('"', true)
+lex:add_rule('string', token(lexer.STRING, sq_str + dq_str))
+
+-- Comments and text in parentheses at the line end
+local comment = lexer.range('/*', '*/')
+local description = lexer.range('(', ')') * lexer.newline
+lex:add_rule('comment', token(lexer.COMMENT, comment + description))
+
+lex:add_rule('result', token(lexer.TYPE, B(' = ') * lexer.integer))
+lex:add_rule('identifier', token(lexer.IDENTIFIER, lexer.word))
+lex:add_rule('number', token(lexer.NUMBER, lexer.float + lexer.integer))
+lex:add_rule('operator', token(lexer.OPERATOR, S('+-/*%<>~!=^&|?~:;,.()[]{}')))
+
+return lex


### PR DESCRIPTION
Mistakenly considered included as a part of port of #13 in #68, but it has never been.

Again, I have a problem with what to write into lpeg.properties. In vis we have

```lua
        strace = {
                detect = function(_, data)
                        return data:match("^execve%(")
                end
        },
```

but that’s probably something scintilua cannot do, right?