### PR TITLE
Move tr literal to regex rule in perl lexer

### DIFF
--- a/lexers/perl.lua
+++ b/lexers/perl.lua
@@ -65,14 +65,14 @@ end)
 local lit_str = 'q' * P('q')^-1 * literal_delimited
 local lit_array = 'qw' * literal_delimited
 local lit_cmd = 'qx' * literal_delimited
-local lit_tr = (P('tr') + 'y') * literal_delimited2 * S('cds')^0
 local string = lex:tag(lexer.STRING,
-  sq_str + dq_str + cmd_str + heredoc + lit_str + lit_array + lit_cmd + lit_tr)
+  sq_str + dq_str + cmd_str + heredoc + lit_str + lit_array + lit_cmd)
 local regex_str = lexer.after_set('-<>+*!~\\=%&|^?:;([{', lexer.range('/', true) * S('imosx')^0)
 local lit_regex = 'qr' * literal_delimited * S('imosx')^0
 local lit_match = 'm' * literal_delimited * S('cgimosx')^0
 local lit_sub = 's' * literal_delimited2 * S('ecgimosx')^0
-local regex = lex:tag(lexer.REGEX, regex_str + lit_regex + lit_match + lit_sub)
+local lit_tr = (P('tr') + 'y') * literal_delimited2 * S('cds')^0
+local regex = lex:tag(lexer.REGEX, regex_str + lit_regex + lit_match + lit_sub + lit_tr)
 lex:add_rule('string', string + regex)
 
 -- Functions.


### PR DESCRIPTION
`y/a/b/` should be highlighted as a regex, same as `tr/a/b/`. Technically, this should already work but it doesn't (at least not for me).
Moving `lit_tr` to the regex rule fixes this for me.