### PR TITLE
Highlight types in number literals for Rust

### DIFF
--- a/lexers/rust.lua
+++ b/lexers/rust.lua
@@ -13,27 +13,11 @@ lex:add_rule('keyword', lex:tag(lexer.KEYWORD, lex:word_match(lexer.KEYWORD)))
 -- Library types.
 lex:add_rule('library', lex:tag(lexer.TYPE, lexer.upper * (lexer.lower + lexer.dec_num)^1))
 
--- Numbers.
-local identifier = P('r#')^-1 * lexer.word
-local digit = lexer.digit
-local decimal_literal = digit * (digit + '_')^0
-local function integer_suffix(digit) return P('_')^0 * digit * (digit + '_')^0 end
-local function opt_cap(patt) return C(patt^-1) end
-local float = decimal_literal *
-  (Cmt(opt_cap('.' * decimal_literal) * opt_cap(S('eE') * S('+-')^-1 * integer_suffix(digit)) *
-    opt_cap(P('f32') + 'f64'), function(input, index, decimals, exponent, type)
-    return decimals ~= '' or exponent ~= '' or type ~= ''
-  end) + '.' * -(S('._') + identifier))
-local function prefixed_integer(prefix, digit) return P(prefix) * integer_suffix(digit) end
-local bin = prefixed_integer('0b', S('01'))
-local oct = prefixed_integer('0o', lpeg.R('07'))
-local hex = prefixed_integer('0x', lexer.xdigit)
-local integer = (bin + oct + hex + decimal_literal) *
-  (S('iu') * (P('8') + '16' + '32' + '64' + '128' + 'size'))^-1
-lex:add_rule('number', lex:tag(lexer.NUMBER, float + integer))
-
 -- Types.
 lex:add_rule('type', lex:tag(lexer.TYPE, lex:word_match(lexer.TYPE)))
+
+-- Numbers.
+lex:add_rule('number', lex:tag(lexer.NUMBER, lexer.number_("_")))
 
 -- Lifetime annotation.
 lex:add_rule('lifetime', lex:tag(lexer.OPERATOR, S('<&') * P("'")))


### PR DESCRIPTION
Some other editors highlight the type part of number literals. E.g. in `456i32` the `i32` part will be highlighted as type instead of a number.
I think this makes a lot of sense and should be the default behavior in Textadept as well.

There is probably a better way to do this. The suggested change does not work with octal number literals (e.g. `0o01234u32`).

What are your thoughts on this?