### PR TITLE
Add c23 attributes

### DIFF
--- a/lexers/ansi_c.lua
+++ b/lexers/ansi_c.lua
@@ -52,7 +52,9 @@ local preproc = lex:tag(lexer.PREPROCESSOR, '#' * S('\t ')^0 * lex:word_match(le
 lex:add_rule('preprocessor', include + preproc)
 
 -- Attributes.
-lex:add_rule('attribute', lex:tag(lexer.ATTRIBUTE, '[[' * (lex:word_match(lexer.ATTRIBUTE) + (lexer.word * ':' * lexer.word)) * ']]'))
+lex:add_rule('attribute', lex:tag(lexer.ATTRIBUTE, '[[' * 
+  (lex:word_match(lexer.ATTRIBUTE) + (lexer.word * ':' * lexer.word)) * 
+  lexer.range('(', ')')^-1 * ']]'))
 
 -- Operators.
 lex:add_rule('operator', lex:tag(lexer.OPERATOR, S('+-/*%<>~!=^&|?~:;,.()[]{}')))

--- a/lexers/ansi_c.lua
+++ b/lexers/ansi_c.lua
@@ -53,7 +53,7 @@ lex:add_rule('preprocessor', include + preproc)
 
 -- Attributes.
 lex:add_rule('attribute', lex:tag(lexer.ATTRIBUTE, '[[' * 
-  (lex:word_match(lexer.ATTRIBUTE) + (lexer.word * ':' * lexer.word)) * 
+  (lex:word_match(lexer.ATTRIBUTE) + (lexer.word * '::' * lexer.word)) * 
   lexer.range('(', ')')^-1 * ']]'))
 
 -- Operators.

--- a/lexers/ansi_c.lua
+++ b/lexers/ansi_c.lua
@@ -52,9 +52,9 @@ local preproc = lex:tag(lexer.PREPROCESSOR, '#' * S('\t ')^0 * lex:word_match(le
 lex:add_rule('preprocessor', include + preproc)
 
 -- Attributes.
-lex:add_rule('attribute', lex:tag(lexer.ATTRIBUTE, '[[' * 
-  (lex:word_match(lexer.ATTRIBUTE) + (lexer.word * '::' * lexer.word)) * 
-  lexer.range('(', ')')^-1 * ']]'))
+lex:add_rule('attribute', lex:tag(lexer.ATTRIBUTE, '[[' *
+  ((lex:word_match(lexer.ATTRIBUTE) + (lexer.word * '::' * lexer.word)) *
+  lexer.range('(', ')')^-1 * (P(',') * P(' ')^0)^-1)^1 * ']]'))
 
 -- Operators.
 lex:add_rule('operator', lex:tag(lexer.OPERATOR, S('+-/*%<>~!=^&|?~:;,.()[]{}')))

--- a/lexers/ansi_c.lua
+++ b/lexers/ansi_c.lua
@@ -52,7 +52,7 @@ local preproc = lex:tag(lexer.PREPROCESSOR, '#' * S('\t ')^0 * lex:word_match(le
 lex:add_rule('preprocessor', include + preproc)
 
 -- Attributes.
-lex:add_rule('attribute', lex:tag(lexer.ATTRIBUTE, '[[' * (lex:word_match(lexer.ATTRIBUTE)+ (lexer.word * ':' * lexer.word)) * ']]'))
+lex:add_rule('attribute', lex:tag(lexer.ATTRIBUTE, '[[' * (lex:word_match(lexer.ATTRIBUTE) + (lexer.word * ':' * lexer.word)) * ']]'))
 
 -- Operators.
 lex:add_rule('operator', lex:tag(lexer.OPERATOR, S('+-/*%<>~!=^&|?~:;,.()[]{}')))

--- a/lexers/ansi_c.lua
+++ b/lexers/ansi_c.lua
@@ -51,6 +51,9 @@ local include = lex:tag(lexer.PREPROCESSOR, '#' * S('\t ')^0 * 'include') *
 local preproc = lex:tag(lexer.PREPROCESSOR, '#' * S('\t ')^0 * lex:word_match(lexer.PREPROCESSOR))
 lex:add_rule('preprocessor', include + preproc)
 
+-- Attributes.
+lex:add_rule('attribute', lex:tag(lexer.ATTRIBUTE, '[[' * (lex:word_match(lexer.ATTRIBUTE)+ (lexer.word * ':' * lexer.word)) * ']]'))
+
 -- Operators.
 lex:add_rule('operator', lex:tag(lexer.OPERATOR, S('+-/*%<>~!=^&|?~:;,.()[]{}')))
 
@@ -192,6 +195,11 @@ lex:set_word_list(lexer.CONSTANT_BUILTIN, {
 lex:set_word_list(lexer.PREPROCESSOR, {
   'define', 'defined', 'elif', 'else', 'endif', 'error', 'if', 'ifdef', 'ifndef', 'line', 'pragma',
   'undef'
+})
+
+lex:set_word_list(lexer.ATTRIBUTE, { -- C23
+  'depreciated', 'fallthrough', 'maybe_unused',
+  'nodiscard', 'noreturn', '_Noreturn', 'unsequenced', 'reproducible'
 })
 
 lexer.property['scintillua.comment'] = '//'


### PR DESCRIPTION
From: https://github.com/martanne/vis/pull/1207

Minor change to the `ansi_c` parser, adds highlighting support for every [c23 attribute](https://en.cppreference.com/w/c/language/attributes) as well as vendor-specific attributes of the form `[[a::b]]`