### PR TITLE
Adding Factor lexer

### DIFF
--- a/lexers/factor.lua
+++ b/lexers/factor.lua
@@ -1,0 +1,104 @@
+--[[
+Lexer for the Factor programming language (http://factorcode.org)
+Copyright 2013 Michael T. Richter <ttmrichter@gmail.com>
+
+This program is free software and comes without any warranty, express nor
+implied.  It is, in short, warranted to do absolutely nothing but (possibly)
+occupy storage space.  You can redistribute it and/or modify it under the terms
+of the Do What The Fuck You Want To Public License, Version 2, as published by
+Sam Hocevar.  Consult http://www.wtfpl.net/txt/copying for full legal details.
+
+BUGS
+====
+At this time the lexer is usable, but not perfect.  Problems include:
+ * identifiers like (foo) get treated and coloured like stack declarations
+ * other as-yet unknown display bugs  :-)
+
+These make a few source files less than lovely and will be fixed as possible.
+(Making syntax highlighting for a language as syntactically flexible as Factor
+turns out to be a non-trivial task!)
+]]
+
+local l = lexer
+local token, style, color, word_match = l.token, l.style, l.color, l.word_match
+local P, R, S = lpeg.P, lpeg.R, lpeg.S
+
+local M = {_NAME = 'factor'}
+
+-- General building blocks.
+local pre = R'AZ'^1
+local post = pre
+local opt_pre = pre^-1
+local opt_post = opt_pre
+
+-- Whitespace.
+local ws = token(l.WHITESPACE, l.space^1)
+
+-- Comments.
+local comment = token(l.COMMENT, P'#'^-1 * P'!' * l.nonnewline^0)
+
+-- Strings.
+local dq1_str = opt_pre * l.delimited_range('"', '\\')
+local dq3_str = l.delimited_range('"""', '\\')
+local string = token(l.STRING, dq1_str + dq3_str)
+
+-- Numbers.
+-- Note that complex literals like C{ 1/3 27.3 } are not covered by this lexer.
+-- The C{ ... } notation is treated as an operator--to be specific a
+-- "constructor" (for want of a better term).
+local hex_digits       = R('09', 'af', 'AF')^1
+local binary           = P'-'^-1 * P'0b' * S'01'^1
+local octal            = P'-'^-1 * P'0o' * R'07'^1
+local decimal          = P'-'^-1 * R'09'^1
+local hexadecimal      = P'-'^-1 * P'0x' * hex_digits^1
+local integer          = binary + octal + hexadecimal + decimal
+local ratio            = decimal * P'/' * decimal
+local dfloat_component = decimal * P'.' * decimal^-1
+local hfloat_component = hexadecimal * (P'.' * hex_digits^-1)^-1
+local float            = (dfloat_component * (S'eE' * decimal)^-1) +
+                         (hfloat_component * S'pP' * decimal)      +
+                         (ratio * P'.')                            +
+                         (P'-'^-1 * P'1/0.')                       +
+                         (P'0/0')
+
+local number = token(l.NUMBER, (float + ratio + integer) * #ws)
+
+-- Keywords.
+-- Things like NAN:, USE:, USING:, POSTPONE:, etc. are considered keywords,
+-- as are similar words that end in #.  Patterns like <<WORD ... WORD>> are
+-- similarly considered to be "keywords" (for want of a better term).
+local colon_words = pre * S':#' + S':;'^1
+local angle_words = (P'<'^1 * post) +
+                    (pre * P'>'^1)
+local keyword = token(l.KEYWORD, (colon_words + angle_words) * #ws)
+
+-- Operators.
+-- The usual suspects like braces, brackets, angle brackets, parens, etc. are
+-- considered to be operators.  They may, however, have prefixes like C{ ... }.
+local constructor_words = opt_pre * P'{' + P'}' +
+                          opt_pre * P'[' + P']' +
+                          opt_pre * P'<' + P'>' +
+                          pre     * P'(' + P')'
+local stack_declaration = l.delimited_range('()')
+local other_operators = S'+-*/<>'
+local operator = token(l.OPERATOR, (stack_declaration +
+                                   constructor_words +
+                                   other_operators) * #ws)
+
+-- Identifiers.
+-- Identifiers can be practically anything but whitespace.
+local symbols = S'`~!@#$%^&*()_-+={[<>]}:;X,?/'
+local identifier = token(l.IDENTIFIER, (l.alnum + symbols)^1 * #ws)
+
+M._rules = {
+  {'keyword', keyword},
+  {'whitespace', ws},
+  {'string', string},
+  {'comment', comment},
+  {'number', number},
+  {'operator', operator},
+  {'identifier', identifier},
+  {'any_char', l.any_char},
+}
+
+return M

--- a/lexers/factor.lua
+++ b/lexers/factor.lua
@@ -21,19 +21,15 @@ turns out to be a non-trivial task!)
 ]]
 
 local lexer = lexer
-local token, style, color, word_match = lexer.token, lexer.style, lexer.color, lexer.word_match
 local P, R, S = lpeg.P, lpeg.R, lpeg.S
 
-local lex = lexer.new('factor');
+local lex = lexer.new(...);
 
 -- General building blocks.
 local pre = R'AZ'^1
 local post = pre
 local opt_pre = pre^-1
 local opt_post = opt_pre
-
--- Whitespace.
-lex:add_rule('whitespace', lex:tag(lexer.WHITESPACE, lexer.space^1))
 
 -- Comments.
 lex:add_rule('comment', lex:tag(lexer.COMMENT, P'#'^-1 * P'!' * lexer.nonnewline^0))

--- a/tests.lua
+++ b/tests.lua
@@ -1460,6 +1460,38 @@ function test_yaml()
 	assert_lex(yaml, code:match('(|.+)$'), tags, DEFAULT)
 end
 
+-- Tests the Factor lexer.
+function test_factor()
+	local factor = lexer.load('factor')
+
+	local code = [[
+	#!/usr/bin/env factor
+	! comment
+	: foo ( a: integer b -- c )
+	    { 1.5 3/2 1234 1.2e3 } sum + sqrt - ;
+	]]
+
+	local tags = {
+		COMMENT, '#!/usr/bin/env factor', --
+		COMMENT, '! comment', --
+		KEYWORD, ':', --
+		IDENTIFIER, 'foo', --
+		OPERATOR, '( a: integer b -- c )', --
+		OPERATOR, '{', --
+		NUMBER, '1.5', --
+		NUMBER, '3/2', --
+		NUMBER, '1234', --
+		NUMBER, '1.2e3', --
+		OPERATOR, '}', --
+		IDENTIFIER, 'sum', --
+		OPERATOR, '+', --
+		IDENTIFIER, 'sqrt', --
+		OPERATOR, '-', --
+		KEYWORD, ';', --
+	}
+	assert_lex(factor, code, tags)
+end
+
 -- Tests the Python lexer and fold by indentation.
 function test_python()
 	local python = lexer.load('python')

--- a/tests.lua
+++ b/tests.lua
@@ -1468,7 +1468,7 @@ function test_factor()
 	#!/usr/bin/env factor
 	! comment
 	: foo ( a: integer b -- c )
-	    { 1.5 3/2 1234 1.2e3 } sum + sqrt - ;
+	    { 1.5 3/2 1234 1.2e3 } sum + "hello" length sqrt - ;
 	]]
 
 	local tags = {
@@ -1485,6 +1485,8 @@ function test_factor()
 		OPERATOR, '}', --
 		IDENTIFIER, 'sum', --
 		OPERATOR, '+', --
+		STRING, '\"hello\"', --
+		IDENTIFIER, 'length', --
 		IDENTIFIER, 'sqrt', --
 		OPERATOR, '-', --
 		KEYWORD, ';', --


### PR DESCRIPTION
The [Factor programming language](https://github.com/factor/factor) project has had a copy of a lexer for Factor that should probably be upstreamed.

https://github.com/factor/factor/blob/881aa979b86034a9330db9f372e7c6cd10a313f8/misc/textadept/lexers/factor.lua

I pulled it out for upstreaming.