### PR TITLE
C adjustments

### DIFF
--- a/lexers/c.lua
+++ b/lexers/c.lua
@@ -43,7 +43,7 @@ lex:add_rule('comment', lex:tag(lexer.COMMENT, line_comment + block_comment))
 
 -- Numbers.
 local integer = lexer.integer * lexer.word_match('u l ll ul ull lu llu', true)^-1
-local float = lexer.float * P('f')^-1
+local float = lexer.float * lexer.word_match('f l df dd dl i j', true)^-1
 lex:add_rule('number', lex:tag(lexer.NUMBER, float + integer))
 
 -- Preprocessor.


### PR DESCRIPTION
The `ssize_t` stuff in the first commit needs no real explanation.

However; the Linux kernel stuff is ... more dubious.

It would be _nice_ to have a comprehensive list of types, constants, functions, and macros that are in the kernel's various headers; unsurprisingly, there are thousands of them, so including them _all_ is infeasible; I'm frightened to think of what it would do to performance. This commit adds only the types in `include/linux/types.h`, and the corresponding constants in `include/linux/limits.h`.

At some point down the road, I may take a closer look through the source and send another pull request once I'm better able to determine what the common vs uncommon members are, and create a narrower selection of the important ones. `kmalloc()`? Good to have. `phy_interface_set_rgmii()`? Don't think anyone will miss it.

Speaking of things nobody will miss--I'm going to do a little more digging and then see if `U32_MIN` can really be removed. May not even be worth bothering to include it when you make this commit--there are zero references to it anywhere in the kernel.

I normally use vis to test these adjustments; but I'm not sure how to reconcile the "two groups of thing in the same tag" problem, as it disabled syntax highlighting for both groups--maybe that's on their side & they should deal with it in their upcoming merge, maybe it's here. Let me know how you want that handled.