### PR TITLE
standardize definition of lexer and lex, remove whitespace definition

### DIFF
--- a/lexers/actionscript.lua
+++ b/lexers/actionscript.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Actionscript LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('actionscript')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/ada.lua
+++ b/lexers/ada.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Ada LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('ada')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match({

--- a/lexers/antlr.lua
+++ b/lexers/antlr.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- ANTLR LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('antlr')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/apdl.lua
+++ b/lexers/apdl.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- APDL LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
 local lex = lexer.new('apdl', {case_insensitive_fold_points = true})
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match({

--- a/lexers/apl.lua
+++ b/lexers/apl.lua
@@ -1,14 +1,11 @@
 -- Copyright 2015-2025 David B. Lamkins <david@lamkins.net>. See LICENSE.
 -- APL LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('apl')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Comments.
 lex:add_rule('comment', token(lexer.COMMENT, lexer.to_eol(P('⍝') + '#')))

--- a/lexers/applescript.lua
+++ b/lexers/applescript.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Applescript LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('applescript')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match({

--- a/lexers/batch.lua
+++ b/lexers/batch.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Batch LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
 local lex = lexer.new('batch', {case_insensitive_fold_points = true})
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match({

--- a/lexers/boo.lua
+++ b/lexers/boo.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Boo LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('boo')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/caml.lua
+++ b/lexers/caml.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- OCaml LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('caml')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/clojure.lua
+++ b/lexers/clojure.lua
@@ -2,14 +2,11 @@
 -- Clojure LPeg lexer.
 -- Contributed by Christos Chatzifountas.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('clojure')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/coffeescript.lua
+++ b/lexers/coffeescript.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- CoffeeScript LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local word_match = lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
 local lex = lexer.new('coffeescript', {fold_by_indentation = true})
-
--- Whitespace.
-lex:add_rule('whitespace', lex:tag(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', lex:tag(lexer.KEYWORD, word_match{

--- a/lexers/context.lua
+++ b/lexers/context.lua
@@ -1,18 +1,15 @@
 -- Copyright 2006-2025 Robert Gieseke, Lars Otter. See LICENSE.
 -- ConTeXt LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('context')
+local lex = lexer.new(...)
 
 -- TeX and ConTeXt mkiv environment definitions.
 local beginend = (P('begin') + 'end')
 local startstop = (P('start') + 'stop')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Comments.
 lex:add_rule('comment', token(lexer.COMMENT, lexer.to_eol('%')))

--- a/lexers/crystal.lua
+++ b/lexers/crystal.lua
@@ -2,14 +2,11 @@
 -- Copyright 2017 Michel Martens.
 -- Crystal LPeg lexer (based on Ruby).
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('crystal')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/csharp.lua
+++ b/lexers/csharp.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- C# LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('csharp')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/dart.lua
+++ b/lexers/dart.lua
@@ -2,14 +2,11 @@
 -- Dart LPeg lexer.
 -- Written by Brian Schott (@Hackerpilot on Github).
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('dart')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/dot.lua
+++ b/lexers/dot.lua
@@ -2,14 +2,11 @@
 -- Dot LPeg lexer.
 -- Based off of lexer code by Mitchell.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('dot')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/eiffel.lua
+++ b/lexers/eiffel.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Eiffel LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('eiffel')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/elixir.lua
+++ b/lexers/elixir.lua
@@ -2,14 +2,11 @@
 -- Contributed by Richard Philips.
 -- Elixir LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local B, P, S = lpeg.B, lpeg.P, lpeg.S
 
 local lex = lexer.new('elixir', {fold_by_indentation = true})
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Sigils.
 local sigil11 = '~' * S('CRSW') * lexer.range('<', '>')

--- a/lexers/elm.lua
+++ b/lexers/elm.lua
@@ -2,14 +2,11 @@
 -- Elm LPeg lexer
 -- Adapted from Haskell LPeg lexer by Karl Schultheisz.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
 local lex = lexer.new('elm', {fold_by_indentation = true})
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match(

--- a/lexers/erlang.lua
+++ b/lexers/erlang.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Erlang LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('erlang')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/fantom.lua
+++ b/lexers/fantom.lua
@@ -2,15 +2,11 @@
 -- Fantom LPeg lexer.
 -- Based on Java LPeg lexer by Mitchell and Vim's Fantom syntax.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('fantom')
-
--- Whitespace.
-local ws = token(lexer.WHITESPACE, lexer.space^1)
-lex:add_rule('whitespace', ws)
+local lex = lexer.new(...)
 
 -- Classes.
 local type = token(lexer.TYPE, lexer.word)

--- a/lexers/faust.lua
+++ b/lexers/faust.lua
@@ -1,14 +1,11 @@
 -- Copyright 2015-2025 David B. Lamkins <david@lamkins.net>. See LICENSE.
 -- Faust LPeg lexer, see http://faust.grame.fr/
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('faust')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/fennel.lua
+++ b/lexers/fennel.lua
@@ -2,14 +2,11 @@
 -- Fennel LPeg lexer.
 -- Contributed by Momohime Honda.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
 local lex = lexer.new('fennel', {inherit = lexer.load('lua')})
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:modify_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/fish.lua
+++ b/lexers/fish.lua
@@ -1,14 +1,11 @@
 -- Copyright 2015-2025 Jason Schindler. See LICENSE.
 -- Fish (http://fishshell.com/) script LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('fish')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/forth.lua
+++ b/lexers/forth.lua
@@ -2,14 +2,11 @@
 -- Forth LPeg lexer.
 -- Contributions from Joseph Eib.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('forth')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Strings.
 local c_str = 'c' * lexer.range('"', true, false)

--- a/lexers/fortran.lua
+++ b/lexers/fortran.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Fortran LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('fortran')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Comments.
 local line_comment = lexer.to_eol(lexer.starts_line(S('CcDd!*')) + '!')

--- a/lexers/fsharp.lua
+++ b/lexers/fsharp.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- F# LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
 local lex = lexer.new('fsharp', {fold_by_indentation = true})
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/gap.lua
+++ b/lexers/gap.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Gap LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('gap')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/gettext.lua
+++ b/lexers/gettext.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Gettext LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('gettext')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match(

--- a/lexers/gherkin.lua
+++ b/lexers/gherkin.lua
@@ -1,14 +1,11 @@
 -- Copyright 2015-2025 Jason Schindler. See LICENSE.
 -- Gherkin (https://github.com/cucumber/cucumber/wiki/Gherkin) LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
 local lex = lexer.new('gherkin', {fold_by_indentation = true})
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match(

--- a/lexers/gleam.lua
+++ b/lexers/gleam.lua
@@ -3,17 +3,13 @@
 -- https://gleam.run/
 -- Contributed by Tynan Beatty
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
 local KEY, OP = lexer.KEYWORD, lexer.OPERATOR
 
-local lex = lexer.new('gleam')
-
--- Whitespace.
-local gleam_ws = token(lexer.WHITESPACE, lexer.space^1)
-lex:add_rule('whitespace', gleam_ws)
+local lex = lexer.new(...)
 
 -- Types.
 local typ_tok = token(lexer.TYPE, lexer.upper * lexer.alnum^0)

--- a/lexers/groovy.lua
+++ b/lexers/groovy.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Groovy LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('groovy')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/icon.lua
+++ b/lexers/icon.lua
@@ -3,14 +3,11 @@
 -- http://www.cs.arizona.edu/icon
 -- Contributed by Carl Sturtivant.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('icon')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/idl.lua
+++ b/lexers/idl.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- IDL LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('idl')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/inform.lua
+++ b/lexers/inform.lua
@@ -2,14 +2,11 @@
 -- Inform 6 LPeg lexer for Scintillua.
 -- JMS 2010-04-25.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('inform')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/ini.lua
+++ b/lexers/ini.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Ini LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('ini')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match('true false on off yes no')))

--- a/lexers/io_lang.lua
+++ b/lexers/io_lang.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Io LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('io_lang')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/java.lua
+++ b/lexers/java.lua
@@ -2,7 +2,7 @@
 -- Java LPeg lexer.
 -- Modified by Brian Schott.
 
-local lexer = require('lexer')
+local lexer = lexer
 local P, S = lpeg.P, lpeg.S
 
 local lex = lexer.new(...)

--- a/lexers/jq.lua
+++ b/lexers/jq.lua
@@ -2,14 +2,11 @@
 -- jq 1.6 Lua lexer -- https://stedolan.github.io/jq/wiki
 -- Anonymously contributed.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('jq')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/julia.lua
+++ b/lexers/julia.lua
@@ -1,14 +1,11 @@
 -- Copyright 2020-2025 Tobias Frilling. See LICENSE.
 -- Julia lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local B, P, S = lpeg.B, lpeg.P, lpeg.S
 
-local lex = lexer.new('julia')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 local id = lexer.word * P('!')^0
 

--- a/lexers/ledger.lua
+++ b/lexers/ledger.lua
@@ -1,7 +1,7 @@
 -- Copyright 2015-2025 Charles Lehner. See LICENSE.
 -- ledger journal LPeg lexer, see http://www.ledger-cli.org/
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
@@ -17,9 +17,6 @@ lex:add_rule('amount', token(lexer.NUMBER, delim * (1 - S(';\r\n'))^1))
 
 -- Comments.
 lex:add_rule('comment', token(lexer.COMMENT, lexer.to_eol(S(';#'))))
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Strings.
 local sq_str = lexer.range("'")

--- a/lexers/less.lua
+++ b/lexers/less.lua
@@ -2,7 +2,7 @@
 -- Less CSS LPeg lexer.
 -- http://lesscss.org
 
-local lexer = require('lexer')
+local lexer = lexer
 local token = lexer.token
 local S = lpeg.S
 

--- a/lexers/lilypond.lua
+++ b/lexers/lilypond.lua
@@ -2,14 +2,11 @@
 -- Lilypond LPeg lexer.
 -- TODO Embed Scheme; Notes?, Numbers?
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('lilypond')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords, commands.
 lex:add_rule('keyword', token(lexer.KEYWORD, '\\' * lexer.word))

--- a/lexers/lisp.lua
+++ b/lexers/lisp.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Lisp LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('lisp')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/logtalk.lua
+++ b/lexers/logtalk.lua
@@ -1,7 +1,7 @@
 -- Copyright © 2017-2025 Michael T. Richter <ttmrichter@gmail.com>. See LICENSE.
 -- Logtalk LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
@@ -19,9 +19,6 @@ lex:modify_rule('directive',
 	(indent * token(lexer.OPERATOR, ':-') * token(lexer.WHITESPACE, S(' \t')^0) *
 		token(lexer.PREPROCESSOR, word_match(directives))
 ) + lex:get_rule('directive'))
-
--- Whitespace.
-lex:modify_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 local zero_arity_keywords = {
 	-- extracted from test document in logtalk distribution

--- a/lexers/mediawiki.lua
+++ b/lexers/mediawiki.lua
@@ -2,11 +2,11 @@
 -- MediaWiki LPeg lexer.
 -- Contributed by Alexander Misel.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S, B = lpeg.P, lpeg.S, lpeg.B
 
-local lex = lexer.new('mediawiki')
+local lex = lexer.new(...)
 
 -- Comments.
 lex:add_rule('comment', token(lexer.COMMENT, lexer.range('<!--', '-->')))

--- a/lexers/moonscript.lua
+++ b/lexers/moonscript.lua
@@ -1,14 +1,11 @@
 -- Copyright 2016-2025 Alejandro Baez (https://keybase.io/baez). See LICENSE.
 -- Moonscript LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
 local lex = lexer.new('moonscript', {fold_by_indentation = true})
-
--- Whitespace.
-lex:add_rule('whitspace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Table keys.
 lex:add_rule('tbl_key', token('tbl_key', lexer.word * ':' + ':' * lexer.word))

--- a/lexers/myrddin.lua
+++ b/lexers/myrddin.lua
@@ -1,14 +1,11 @@
 -- Copyright 2017-2025 Michael Forney. See LICENSE
 -- Myrddin LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('myrddin')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/nemerle.lua
+++ b/lexers/nemerle.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Nemerle LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('nemerle')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/networkd.lua
+++ b/lexers/networkd.lua
@@ -1,14 +1,11 @@
 -- Copyright 2016-2025 Christian Hesse. See LICENSE.
 -- systemd networkd file LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
 local lex = lexer.new('networkd', {lex_by_line = true})
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/nim.lua
+++ b/lexers/nim.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Nim LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
 local lex = lexer.new('nim', {fold_by_indentation = true})
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match({

--- a/lexers/nsis.lua
+++ b/lexers/nsis.lua
@@ -2,14 +2,11 @@
 -- NSIS LPeg lexer
 -- Based on NSIS 2.46 docs: http://nsis.sourceforge.net/Docs/.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('nsis')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Comments (4.1).
 local line_comment = lexer.to_eol(S(';#'))

--- a/lexers/objective_c.lua
+++ b/lexers/objective_c.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Objective C LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
 local lex = lexer.new('objective_c')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/pascal.lua
+++ b/lexers/pascal.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Pascal LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('pascal')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match({

--- a/lexers/pike.lua
+++ b/lexers/pike.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Pike LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('pike')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/pkgbuild.lua
+++ b/lexers/pkgbuild.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 gwash. See LICENSE.
 -- Archlinux PKGBUILD LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('pkgbuild')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Comments.
 lex:add_rule('comment', token(lexer.COMMENT, lexer.to_eol('#')))

--- a/lexers/pony.lua
+++ b/lexers/pony.lua
@@ -1,15 +1,11 @@
 -- Copyright 2017-2025 Murray Calavera. See LICENSE.
 -- Pony LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('pony')
-
--- Whitespace.
-local ws = token(lexer.WHITESPACE, lexer.space^1)
-lex:add_rule('whitespace', ws)
+local lex = lexer.new(...)
 
 -- Capabilities.
 local capability = token(lexer.LABEL, word_match('box iso ref tag trn val'))

--- a/lexers/powershell.lua
+++ b/lexers/powershell.lua
@@ -2,14 +2,11 @@
 -- PowerShell LPeg lexer.
 -- Contributed by Jeff Stone.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('powershell')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Comments.
 lex:add_rule('comment', token(lexer.COMMENT, lexer.to_eol('#')))

--- a/lexers/prolog.lua
+++ b/lexers/prolog.lua
@@ -23,12 +23,12 @@
   which override operators.
 ]]
 
-local lexer = require('lexer')
+local lexer = lexer
 
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('prolog')
+local lex = lexer.new(...)
 
 local dialect = lexer.property['prolog.dialect']
 if dialect ~= 'gprolog' and dialog ~= 'swipl' then dialect = 'iso' end
@@ -72,9 +72,6 @@ directives.swipl = directives.iso .. [[
 lex:add_rule('directive',
 	token(lexer.WHITESPACE, lexer.starts_line(S(' \t'))^0) * token(lexer.OPERATOR, ':-') *
 		token(lexer.WHITESPACE, S(' \t')^0) * token(lexer.PREPROCESSOR, word_match(directives[dialect])))
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 local zero_arity_keywords = {}

--- a/lexers/protobuf.lua
+++ b/lexers/protobuf.lua
@@ -2,14 +2,11 @@
 -- Protocol Buffer IDL LPeg lexer.
 -- <https://developers.google.com/protocol-buffers/>
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('protobuf')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/ps.lua
+++ b/lexers/ps.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Postscript LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('ps')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/pure.lua
+++ b/lexers/pure.lua
@@ -1,14 +1,11 @@
 -- Copyright 2015-2025 David B. Lamkins <david@lamkins.net>. See LICENSE.
 -- pure LPeg lexer, see http://purelang.bitbucket.org/
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('pure')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/r.lua
+++ b/lexers/r.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- R LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('r')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/rc.lua
+++ b/lexers/rc.lua
@@ -1,14 +1,11 @@
 -- Copyright 2017-2025 Michael Forney. See LICENSE.
 -- rc LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('rc')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/reason.lua
+++ b/lexers/reason.lua
@@ -1,14 +1,11 @@
 -- Copyright 2018-2025 Hugo O. Rivera. See LICENSE.
 -- Reason (https://reasonml.github.io/) LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('reason')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/rebol.lua
+++ b/lexers/rebol.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Rebol LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('rebol')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Comments.
 local line_comment = lexer.to_eol(';')

--- a/lexers/rest.lua
+++ b/lexers/rest.lua
@@ -1,11 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- reStructuredText LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match, starts_line = lexer.token, lexer.word_match, lexer.starts_line
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('rest')
+local lex = lexer.new(...)
 
 -- Literal block.
 local block = '::' * (lexer.newline + -1) * function(input, index)
@@ -139,9 +139,6 @@ lex:add_rule('title', token(lexer.HEADING, overline + underline))
 
 -- Line block.
 lex:add_rule('line_block_char', token(lexer.OPERATOR, starts_line(any_indent * '|')))
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, S(' \t')^1 + lexer.newline^1))
 
 -- Inline markup.
 local strong = token(lexer.BOLD, lexer.range('**'))

--- a/lexers/rexx.lua
+++ b/lexers/rexx.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Rexx LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('rexx')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match({

--- a/lexers/routeros.lua
+++ b/lexers/routeros.lua
@@ -1,14 +1,11 @@
 -- Copyright 2020-2025 Christian Hesse. See LICENSE.
 -- Mikrotik RouterOS script LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('routeros')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/rpmspec.lua
+++ b/lexers/rpmspec.lua
@@ -1,13 +1,10 @@
 -- Copyright 2022-2025 Matej Cepl mcepl.att.cepl.eu. See LICENSE.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('rpmspec')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Comments.
 lex:add_rule('comment', token(lexer.COMMENT, lexer.to_eol('#')))

--- a/lexers/scala.lua
+++ b/lexers/scala.lua
@@ -1,15 +1,11 @@
 -- Copyright 2006-2025 JMS. See LICENSE.
 -- Scala LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('scala')
-
--- Whitespace.
-local ws = token(lexer.WHITESPACE, lexer.space^1)
-lex:add_rule('whitespace', ws)
+local lex = lexer.new(...)
 
 -- Classes.
 lex:add_rule('class', token(lexer.KEYWORD, 'class') * ws^1 * token(lexer.CLASS, lexer.word))

--- a/lexers/scheme.lua
+++ b/lexers/scheme.lua
@@ -2,14 +2,11 @@
 -- Scheme LPeg lexer.
 -- Contributions by Murray Calavera.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('scheme')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/smalltalk.lua
+++ b/lexers/smalltalk.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Smalltalk LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('smalltalk')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match(

--- a/lexers/sml.lua
+++ b/lexers/sml.lua
@@ -1,15 +1,11 @@
 -- Copyright 2017-2025 Murray Calavera. See LICENSE.
 -- Standard ML LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('sml')
-
--- Whitespace.
-local ws = token(lexer.WHITESPACE, lexer.space^1)
-lex:add_rule('whitespace', ws)
+local lex = lexer.new(...)
 
 -- Structures.
 local id = (lexer.alnum + "'" + '_')^0

--- a/lexers/snobol4.lua
+++ b/lexers/snobol4.lua
@@ -2,14 +2,11 @@
 -- SNOBOL4 lexer.
 -- This lexer works with classic SNOBOL4 as well as the CSNOBOL4 extensions.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local B, P, S = lpeg.B, lpeg.P, lpeg.S
 
 local lex = lexer.new('snobol4')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match({

--- a/lexers/spin.lua
+++ b/lexers/spin.lua
@@ -1,14 +1,11 @@
 -- Copyright 2017-2025 David B. Lamkins <david@lamkins.net>. See LICENSE.
 -- Spin LPeg lexer, see https://www.parallax.com/microcontrollers/propeller.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, R, S = lpeg.P, lpeg.R, lpeg.S
 
-local lex = lexer.new('spin')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/sql.lua
+++ b/lexers/sql.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- SQL LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('sql')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match({

--- a/lexers/systemd.lua
+++ b/lexers/systemd.lua
@@ -1,14 +1,11 @@
 -- Copyright 2016-2025 Christian Hesse. See LICENSE.
 -- systemd unit file LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
 local lex = lexer.new('systemd', {lex_by_line = true})
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/tcl.lua
+++ b/lexers/tcl.lua
@@ -3,14 +3,11 @@
 -- This lexer follows the TCL dodekalogue (http://wiki.tcl.tk/10259).
 -- It is based on the previous lexer by Mitchell.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('tcl')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Comment.
 lex:add_rule('comment', token(lexer.COMMENT, lexer.to_eol('#' * P(function(input, index)

--- a/lexers/text.lua
+++ b/lexers/text.lua
@@ -1,11 +1,9 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Text LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 
-local lex = lexer.new('text')
-
-lex:add_rule('whitespace', lexer.token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 lex:add_rule('text', lexer.token(lexer.DEFAULT, (1 - lexer.space)^1))
 

--- a/lexers/txt2tags.lua
+++ b/lexers/txt2tags.lua
@@ -4,15 +4,12 @@
 -- [https://txt2tags.org/doc/english/rules.t2t])
 -- Contributed by Julien L.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 local nonspace = lexer.any - lexer.space
 
-local lex = lexer.new('txt2tags')
-
--- Whitespace.
-local ws = token(lexer.WHITESPACE, (lexer.space - lexer.newline)^1)
+local lex = lexer.new(...)
 
 -- Titles
 local alphanumeric = lexer.alnum + S('_-')
@@ -108,7 +105,6 @@ lex:add_rule('link', link)
 lex:add_rule('line', line)
 lex:add_rule('header', header)
 lex:add_rule('comment', comment)
-lex:add_rule('whitespace', ws)
 lex:add_rule('image', image)
 lex:add_rule('macro', macro)
 lex:add_rule('inline', inline)

--- a/lexers/vala.lua
+++ b/lexers/vala.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Vala LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('vala')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/vcard.lua
+++ b/lexers/vcard.lua
@@ -1,14 +1,11 @@
 -- Copyright (c) 2015-2025 Piotr Orzechowski [drzewo.org]. See LICENSE.
 -- vCard 2.1, 3.0 and 4.0 LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('vcard')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Begin vCard, end vCard.
 lex:add_rule('begin_sequence', token(lexer.KEYWORD, 'BEGIN') * token(lexer.OPERATOR, ':') *

--- a/lexers/verilog.lua
+++ b/lexers/verilog.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Verilog LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('verilog')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/vhdl.lua
+++ b/lexers/vhdl.lua
@@ -1,14 +1,11 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- VHDL LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('vhdl')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/xs.lua
+++ b/lexers/xs.lua
@@ -2,14 +2,11 @@
 -- xs LPeg lexer.
 -- Adapted from rc lexer by Michael Forney.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('xs')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{

--- a/lexers/xtend.lua
+++ b/lexers/xtend.lua
@@ -1,15 +1,11 @@
 -- Copyright (c) 2014-2025 Piotr Orzechowski [drzewo.org]. See LICENSE.
 -- Xtend LPeg lexer.
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('xtend')
-
--- Whitespace.
-local ws = token(lexer.WHITESPACE, lexer.space^1)
-lex:add_rule('whitespace', ws)
+local lex = lexer.new(...)
 
 -- Classes.
 lex:add_rule('class', token(lexer.KEYWORD, 'class') * ws^1 * token(lexer.CLASS, lexer.word))

--- a/lexers/zig.lua
+++ b/lexers/zig.lua
@@ -2,14 +2,11 @@
 -- Zig LPeg lexer.
 -- (Based on the C++ LPeg lexer from Mitchell.)
 
-local lexer = require('lexer')
+local lexer = lexer
 local token, word_match = lexer.token, lexer.word_match
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('zig')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
 lex:add_rule('keyword', token(lexer.KEYWORD, word_match{


### PR DESCRIPTION
This should be mostly mechanical conversion, should be non-controversial.

References: https://github.com/orbitalquark/scintillua/issues/76