### PR TITLE
fix: modernize ini lexer

### DIFF
--- a/lexers/ini.lua
+++ b/lexers/ini.lua
@@ -1,38 +1,39 @@
 -- Copyright 2006-2025 Mitchell. See LICENSE.
 -- Ini LPeg lexer.
 
-local lexer = require('lexer')
-local token, word_match = lexer.token, lexer.word_match
+local lexer = lexer
 local P, S = lpeg.P, lpeg.S
 
-local lex = lexer.new('ini')
-
--- Whitespace.
-lex:add_rule('whitespace', token(lexer.WHITESPACE, lexer.space^1))
+local lex = lexer.new(...)
 
 -- Keywords.
-lex:add_rule('keyword', token(lexer.KEYWORD, word_match('true false on off yes no')))
+lex:add_rule('keyword', lex:tag(lexer.KEYWORD, lex:word_match(lexer.KEYWORD)))
 
 -- Identifiers.
-lex:add_rule('identifier', token(lexer.IDENTIFIER, (lexer.alpha + '_') * (lexer.alnum + S('_.'))^0))
+-- Allows periods within identifiers for dotted keys (e.g., 'foo.bar').
+lex:add_rule('identifier',
+    lex:tag(lexer.IDENTIFIER, (lexer.alpha + '_') * (lexer.alnum + S('_. '))^0))
 
 -- Strings.
 local sq_str = lexer.range("'")
 local dq_str = lexer.range('"')
-lex:add_rule('string', token(lexer.STRING, sq_str + dq_str))
+lex:add_rule('string', lex:tag(lexer.STRING, sq_str + dq_str))
 
--- Labels.
-lex:add_rule('label', token(lexer.LABEL, lexer.range('[', ']', true)))
+-- Labels (Section Headers).
+lex:add_rule('label', lex:tag(lexer.LABEL, lexer.range('[', ']', true)))
 
 -- Comments.
-lex:add_rule('comment', token(lexer.COMMENT, lexer.to_eol(lexer.starts_line(S(';#')))))
+lex:add_rule('comment',
+	lex:tag(lexer.COMMENT, lexer.to_eol(lexer.starts_line(S(';#')))))
 
 -- Numbers.
-local integer = S('+-')^-1 * (lexer.hex_num + lexer.oct_num_('_') + lexer.dec_num_('_'))
-lex:add_rule('number', token(lexer.NUMBER, lexer.float + integer))
+lex:add_rule('number', lex:tag(lexer.NUMBER, lexer.float + lexer.integer))
 
 -- Operators.
-lex:add_rule('operator', token(lexer.OPERATOR, '='))
+lex:add_rule('operator', lex:tag(lexer.OPERATOR, S('=:')))
+
+-- Word lists
+lex:set_word_list(lexer.KEYWORD, {'true', 'false', 'on', 'off', 'yes', 'no'})
 
 lexer.property['scintillua.comment'] = '#'
 


### PR DESCRIPTION
Not completely certain about

```lua
local sq_str = P('L')^-1 * lexer.range("'")
local dq_str = P('L')^-1 * lexer.range('"')
```

Yes, Lua is important for us, but `L` prefix is rather non-standard in the `ini` universe, isn’t it?

References: https://github.com/orbitalquark/scintillua/issues/76