### PR TITLE
rust lexer: remove self as keyword

### DIFF
--- a/lexers/rust.lua
+++ b/lexers/rust.lua
@@ -61,7 +61,7 @@ lex:add_fold_point(lexer.OPERATOR, '{', '}')
 lex:set_word_list(lexer.KEYWORD, {
 	'SelfTy', 'as', 'async', 'await', 'break', 'const', 'continue', 'crate', 'dyn', 'else', 'enum',
 	'extern', 'false', 'fn', 'for', 'if', 'impl', 'in', 'let', 'loop', 'match', 'mod', 'move', 'mut',
-	'pub', 'ref', 'return', 'self', 'static', 'struct', 'super', 'trait', 'true', 'type', 'union',
+	'pub', 'ref', 'return', 'static', 'struct', 'super', 'trait', 'true', 'type', 'union',
 	'unsafe', 'use', 'where', 'while'
 })
 


### PR DESCRIPTION
In Rust, although "self" is technically a keyword, it's used as a regular variable. So to me, when in my code editor [vis](https://github.com/martanne/vis), "self" having the same colour as regular identifiers makes way more sense and makes it more readable.

Lmk what you think. All of this is very subjective. 