### PR TITLE
Update dark.properties to have consistent color list as light

### DIFF
--- a/themes/dark.properties
+++ b/themes/dark.properties
@@ -16,11 +16,10 @@ scintillua.colors.yellow=#999900
 scintillua.colors.lime=#99CC00
 scintillua.colors.green=#009900
 scintillua.colors.teal=#009999
-scintillua.colors.navy=#000099
 scintillua.colors.blue=#0066CC
+scintillua.colors.violet=#6600CC
 scintillua.colors.purple=#990099
 scintillua.colors.magenta=#CC0066
-scintillua.colors.violet=#6600CC
 
 # Default font.
 if PLAT_WIN


### PR DESCRIPTION
Removed unused color, and resorted so light and dark color order is the same for easier comparisons/diffs.