### PR TITLE
Add class/constructor detection rule for Dart

### DIFF
--- a/lexers/dart.lua
+++ b/lexers/dart.lua
@@ -23,6 +23,12 @@ local dq_str = S('r')^-1 * lexer.range('"', true)
 local tq_str = S('r')^-1 * (lexer.range("'''") + lexer.range('"""'))
 lex:add_rule('string', lex:tag(lexer.STRING, tq_str + sq_str + dq_str))
 
+-- Capitalized identifiers (likely classes or constructors).
+local upper = lpeg.R('AZ')
+local alnum = lpeg.R('AZ', 'az', '09') + P('_')
+local capitalized_word = (lexer.word_boundary or P(true)) * upper * alnum^0
+lex:add_rule('constructor', lex:tag(lexer.TYPE, capitalized_word))
+
 -- Functions.
 lex:add_rule('function', lex:tag(lexer.FUNCTION, lexer.word) * #(lexer.space^0 * '('))
 

--- a/lexers/dart.lua
+++ b/lexers/dart.lua
@@ -12,8 +12,13 @@ local lex = lexer.new(...)
 lex:add_rule('keyword', lex:tag(lexer.KEYWORD, lex:word_match(lexer.KEYWORD)))
 -- Built-ins.
 lex:add_rule('constant', lex:tag(lexer.CONSTANT_BUILTIN, lex:word_match(lexer.CONSTANT_BUILTIN)))
--- Types.
-lex:add_rule('type', lex:tag(lexer.TYPE, lex:word_match(lexer.TYPE)))
+
+-- Types (also matches capitalised words)
+local upper = lpeg.R('AZ')
+local alnum = lpeg.R('AZ', 'az', '09') + P('_')
+local capitalized_word = upper * alnum^0
+lex:add_rule('type', lex:tag(lexer.TYPE, lex:word_match(lexer.TYPE) + capitalized_word))
+
 -- Directives
 lex:add_rule('directive', lex:tag(lexer.PREPROCESSOR, lex:word_match(lexer.PREPROCESSOR)))
 
@@ -22,12 +27,6 @@ local sq_str = S('r')^-1 * lexer.range("'", true)
 local dq_str = S('r')^-1 * lexer.range('"', true)
 local tq_str = S('r')^-1 * (lexer.range("'''") + lexer.range('"""'))
 lex:add_rule('string', lex:tag(lexer.STRING, tq_str + sq_str + dq_str))
-
--- Capitalized identifiers (likely classes or constructors).
-local upper = lpeg.R('AZ')
-local alnum = lpeg.R('AZ', 'az', '09') + P('_')
-local capitalized_word = (lexer.word_boundary or P(true)) * upper * alnum^0
-lex:add_rule('constructor', lex:tag(lexer.TYPE, capitalized_word))
 
 -- Functions.
 lex:add_rule('function', lex:tag(lexer.FUNCTION, lexer.word) * #(lexer.space^0 * '('))
@@ -60,7 +59,8 @@ lex:set_word_list(lexer.KEYWORD, {
 	'covariant', 'default', 'do', 'else', 'enum', 'extends', 'factory', 'finally', 'for', 'get', 'if',
 	'implements', 'in', 'interface', 'is', 'mixin', 'on', 'operator', 'rethrow', 'return', 'set',
 	'super', 'switch', 'sync', 'this', 'throw', 'try', 'with', 'while', 'yield', --
-	'base', 'extension', 'external', 'late', 'of', 'required', 'sealed', 'when'
+	'base', 'extension', 'external', 'late', 'of', 'required', 'sealed', 'when', --
+	'typedef', 'void', 'var'
 })
 
 lex:set_word_list(lexer.PREPROCESSOR, {
@@ -72,7 +72,7 @@ lex:set_word_list(lexer.CONSTANT_BUILTIN, {
 })
 
 lex:set_word_list(lexer.TYPE, {
-	'const', 'dynamic', 'final', 'Function', 'new', 'static', 'typedef', 'var', 'void', 'int',
+	'const', 'dynamic', 'final', 'Function', 'new', 'static', 'int',
 	'double', 'String', 'bool', 'List', 'Set', 'Map', 'Future', 'Stream', 'Iterable', 'Object',
 	'Null', 'type'
 })

--- a/lexers/dart.lua
+++ b/lexers/dart.lua
@@ -60,7 +60,7 @@ lex:set_word_list(lexer.KEYWORD, {
 	'implements', 'in', 'interface', 'is', 'mixin', 'on', 'operator', 'rethrow', 'return', 'set',
 	'super', 'switch', 'sync', 'this', 'throw', 'try', 'with', 'while', 'yield', --
 	'base', 'extension', 'external', 'late', 'of', 'required', 'sealed', 'when', --
-	'typedef', 'void', 'var'
+	'typedef', 'void', 'var', 'const', 'final', 'new', 'static'
 })
 
 lex:set_word_list(lexer.PREPROCESSOR, {
@@ -72,9 +72,7 @@ lex:set_word_list(lexer.CONSTANT_BUILTIN, {
 })
 
 lex:set_word_list(lexer.TYPE, {
-	'const', 'dynamic', 'final', 'Function', 'new', 'static', 'int',
-	'double', 'String', 'bool', 'List', 'Set', 'Map', 'Future', 'Stream', 'Iterable', 'Object',
-	'Null', 'type'
+    'dynamic', 'int', 'double', 'bool', 'type'
 })
 
 lexer.property['scintillua.comment'] = '//'

--- a/lexers/dart.lua
+++ b/lexers/dart.lua
@@ -14,9 +14,7 @@ lex:add_rule('keyword', lex:tag(lexer.KEYWORD, lex:word_match(lexer.KEYWORD)))
 lex:add_rule('constant', lex:tag(lexer.CONSTANT_BUILTIN, lex:word_match(lexer.CONSTANT_BUILTIN)))
 
 -- Types (also matches capitalised words)
-local upper = lpeg.R('AZ')
-local alnum = lpeg.R('AZ', 'az', '09') + P('_')
-local capitalized_word = upper * alnum^0
+local capitalized_word = lpeg.R('AZ') * (lpeg.R('AZ', 'az', '09') + P('_'))^0
 lex:add_rule('type', lex:tag(lexer.TYPE, lex:word_match(lexer.TYPE) + capitalized_word))
 
 -- Directives

--- a/lexers/dart.lua
+++ b/lexers/dart.lua
@@ -4,7 +4,7 @@
 -- Migrated by Jamie Drinkell
 
 local lexer = lexer
-local P, S = lpeg.P, lpeg.S
+local P, S, R = lpeg.P, lpeg.S, lpeg.R
 
 local lex = lexer.new(...)
 
@@ -14,8 +14,9 @@ lex:add_rule('keyword', lex:tag(lexer.KEYWORD, lex:word_match(lexer.KEYWORD)))
 lex:add_rule('constant', lex:tag(lexer.CONSTANT_BUILTIN, lex:word_match(lexer.CONSTANT_BUILTIN)))
 
 -- Types (also matches capitalised words)
-local capitalized_word = lpeg.R('AZ') * (lpeg.R('AZ', 'az', '09') + P('_'))^0
-lex:add_rule('type', lex:tag(lexer.TYPE, lex:word_match(lexer.TYPE) + capitalized_word))
+local capitalized_word = R('AZ') * (R('AZ', 'az', '09') + P('_'))^0
+local underscore_then_caps =  P('_') * capitalized_word
+lex:add_rule('type', lex:tag(lexer.TYPE, lex:word_match(lexer.TYPE) + capitalized_word + underscore_then_caps))
 
 -- Directives
 lex:add_rule('directive', lex:tag(lexer.PREPROCESSOR, lex:word_match(lexer.PREPROCESSOR)))


### PR DESCRIPTION
Hi,

I've been playing with this some more and comparing to other editors highlighting, and I've (or well, mostly ChatGPT...) added a rule to highlight classes/constructors. The [Dart Style Guide](https://dart.dev/effective-dart/style) is highly enforced by Dart's LSP so UpperCamelCase words are guaranteed to be a class or constructor.

Thanks,

Jamie

Edit: I just want to clarify that I mostly try not to use ChatGPT/AI, and my previous contributions have been all me with no AI input. But when it comes to Regex and Pattern Matching I'm hapless 😅. Thankfully I did learn a bit about LPeg after I had it explain why it works!