### PR TITLE
Add keyword and functions from Lua 5.5

### DIFF
--- a/lexers/lua.lua
+++ b/lexers/lua.lua
@@ -81,7 +81,8 @@ lex:add_fold_point(lexer.OPERATOR, '{', '}')
 lex:set_word_list(lexer.KEYWORD, {
 	'and', 'break', 'do', 'else', 'elseif', 'end', 'false', 'for', 'function', 'if', 'in', 'local',
 	'or', 'nil', 'not', 'repeat', 'return', 'then', 'true', 'until', 'while', --
-	'goto' -- 5.2
+	'goto', -- 5.2
+	'global' -- 5.5
 })
 
 lex:set_word_list(lexer.FUNCTION_BUILTIN, {
@@ -107,10 +108,12 @@ lex:set_word_list(lexer.FUNCTION_BUILTIN .. '.library', {
 	'table.concat', 'table.insert', 'table.remove', 'table.sort', --
 	'table.pack', 'table.unpack', -- 5.2
 	'table.move', -- 5.3
+	'table.create', -- 5.5
 	'math.abs', 'math.acos', 'math.asin', 'math.atan', 'math.ceil', 'math.cos', 'math.deg',
 	'math.exp', 'math.floor', 'math.fmod', 'math.log', 'math.max', 'math.min', 'math.modf',
 	'math.rad', 'math.random', 'math.randomseed', 'math.sin', 'math.sqrt', 'math.tan', --
 	'math.tointeger', 'math.type', 'math.ult', -- 5.3
+	'math.frexp', 'math.ldexp', -- 5.5
 	'io.close', 'io.flush', 'io.input', 'io.lines', 'io.open', 'io.output', 'io.popen', 'io.read',
 	'io.tmpfile', 'io.type', 'io.write', --
 	'os.clock', 'os.date', 'os.difftime', 'os.execute', 'os.exit', 'os.getenv', 'os.remove',


### PR DESCRIPTION
Diff of relevant part of reference manuals:

```diff
--- 5.4
+++ 5.5
@@ -92,7 +92,9 @@
 math.exp
 math.floor
 math.fmod
+math.frexp
 math.huge
+math.ldexp
 math.log
 math.max
 math.maxinteger
@@ -154,6 +156,7 @@

 table
 table.concat
+table.create
 table.insert
 table.move
 table.pack
```

and syntax

```diff
--- 5.4
+++ 5.5
@@ -16,11 +16,14 @@ stat ::=
     for namelist in explist do block end |
     function funcname funcbody |
     local function Name funcbody |
-    local attnamelist [‘=’ explist]
+    global function Name funcbody |
+    local attnamelist [‘=’ explist] |
+    global attnamelist |
+    global [attrib] ‘*’

-attnamelist ::=  Name attrib {‘,’ Name attrib}
+attnamelist ::=  [attrib] Name [attrib] {‘,’ Name [attrib]}

-attrib ::= [‘<’ Name ‘>’]
+attrib ::= ‘<’ Name ‘>’

 retstat ::= return [explist] [‘;’]

@@ -49,7 +52,9 @@

 funcbody ::= ‘(’ [parlist] ‘)’ block end

-parlist ::= namelist [‘,’ ‘...’] | ‘...’
+parlist ::= namelist [‘,’ varargparam] | varargparam
+
+varargparam ::= ‘...’ [Name]

 tableconstructor ::= ‘{’ [fieldlist] ‘}’

```

I feel like we can leave `...abc` as it is: `abc` acts as an identifier and is matched as such; `...` is left as it was. As for `'global' [attrib] '*'`, `*` is matched as an operator which feels wrong but I'm unsure which one would be more appropriate (identifier? hardly; keyword?).

GitHub decided to switch display names for no reason (again?), seems I'm already in [thanks.md](https://github.com/orbitalquark/scintillua/blob/default/docs/thanks.md?plain=1#L8) so avoid duplicating with different name in case you choose to use this patch.