### PR TITLE
Update Go lexer

### DIFF
--- a/lexers/go.lua
+++ b/lexers/go.lua
@@ -62,8 +62,8 @@ lex:set_word_list(lexer.TYPE, {
 })
 
 lex:set_word_list(lexer.FUNCTION_BUILTIN, {
-	'append', 'cap', 'close', 'complex', 'copy', 'delete', 'imag', 'len', 'make', 'new', 'panic',
-	'print', 'println', 'real', 'recover'
+	'append', 'cap', 'clear', 'close', 'complex', 'copy', 'delete', 'imag', 'len', 'make', 'max',
+	'min', 'new', 'panic', 'print', 'println', 'real', 'recover'
 })
 
 lexer.property['scintillua.comment'] = '//'


### PR DESCRIPTION
This PR adds missing builtin functions: `clear`, `max`, and `min`.