### PR TITLE
Add Asciidoc lexer

### DIFF
--- a/lexers/asciidoc.lua
+++ b/lexers/asciidoc.lua
@@ -1,0 +1,96 @@
+-- Copyright 2025 Matěj Cepl. See LICENSE.
+-- Copyright 2026 Jamie Drinkell. See LICENSE
+-- Asciidoc LPeg lexer.
+
+local lexer = lexer
+local P, S, B = lpeg.P, lpeg.S, lpeg.B
+
+-- TODO: Asciidoctor notes *OPTIONAL* Markdown compatibility
+-- https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#markdown-compatibility
+-- Do we inherit? It only works with asciidoctor, so not all implementations.
+
+local lex = lexer.new(...)
+
+-- Admonitions.
+lex:add_rule('admonition', lex:tag(lexer.KEYWORD, lex:word_match(lexer.KEYWORD) * #S(':')))
+lex:add_rule('block_admonition', lex:tag(lexer.KEYWORD, P('[') * lex:word_match(lexer.KEYWORD) * P(']')))
+lex:set_word_list(lexer.KEYWORD, {"NOTE", "IMPORTANT", "WARNING", "TIP", "CAUTION", "TESTME"})
+
+-- Block elements.
+local function h(n)
+	return lex:tag(string.format('%s.h%s', lexer.HEADING, n),
+		lexer.to_eol(lexer.starts_line(string.rep('=', n))))
+end
+lex:add_rule('header', h(6) + h(5) + h(4) + h(3) + h(2) + h(1))
+lex:add_rule('block_title', lex:tag(lexer.HEADING, lexer.to_eol(lexer.starts_line('.') * lexer.alnum)))
+
+lex:add_rule('hr',
+	lex:tag('hr', lpeg.Cmt(lexer.starts_line(lpeg.C(S("*-'")), true), function(input, index, c)
+		local line = input:match('[^\r\n]*', index):gsub('[ \t]', '')
+		if line:find('[^' .. c .. ']') or #line < 2 then return nil end
+		return (select(2, input:find('\r?\n', index)) or #input) + 1 -- include \n for eolfilled styles
+	end)))
+
+lex:add_rule('list', lex:tag(lexer.LIST,
+	lexer.starts_line(S('*.')^1, true) * S(' \t')))
+
+-- Span elements.
+lex:add_rule('escape', lex:tag(lexer.DEFAULT, P('\\') * 1))
+
+local link_text = lexer.range('[', ']', true)
+local link_target =
+	'(' * (lexer.any - S(') \t'))^0 * (S(' \t')^1 * lexer.range('"', false, false))^-1 * ')'
+local link_url = 'http' * P('s')^-1 * '://' * (lexer.any - lexer.space)^1 +
+	('<' * lexer.alpha^2 * ':' * (lexer.any - lexer.space - '>')^1 * '>')
+lex:add_rule('link', lex:tag(lexer.LINK, P('!')^-1 * link_text * link_target + link_url))
+
+local link_ref = lex:tag(lexer.REFERENCE, link_text * S(' \t')^0 * lexer.range('[', ']', true))
+local ref_link_label = lex:tag(lexer.REFERENCE, lexer.range('[', ']', true) * ':')
+local ws = lex:get_rule('whitespace')
+local ref_link_url = lex:tag(lexer.LINK, (lexer.any - lexer.space)^1)
+local ref_link_title = lex:tag(lexer.STRING, lexer.range('"', true, false) +
+	lexer.range("'", true, false) + lexer.range('(', ')', true))
+lex:add_rule('link_ref', link_ref + ref_link_label * ws * ref_link_url * (ws * ref_link_title)^-1)
+
+local monospace = lpeg.Cmt(lpeg.C(P('`')^1), function(input, index, bt)
+	-- `foo`, ``foo``, ``foo`bar``, `foo``bar` are all allowed.
+	local _, e = input:find('[^`]' .. bt .. '%f[^`]', index)
+	return (e or #input) + 1
+end)
+lex:add_rule('monospace', lex:tag(lexer.CODE, monospace))
+
+local punct_space = lexer.punct + lexer.space
+local hspace = lexer.space - '\n'
+local blank_line = '\n' * hspace^0 * ('\n' + P(-1))
+
+-- Handles flanking delimiters as described in
+-- https://github.github.com/gfm/#emphasis-and-strong-emphasis in the cases where simple
+-- delimited ranges are not sufficient.
+local function flanked_range(s, not_inword)
+	local fl_char = lexer.any - s - lexer.space
+	local left_fl = B(punct_space - s) * s * #fl_char + s * #(fl_char - lexer.punct)
+	local right_fl = B(lexer.punct) * s * #(punct_space - s) + B(fl_char) * s
+	return left_fl * (lexer.any - blank_line - (not_inword and s * #punct_space or s))^0 * right_fl
+end
+
+local asterisk_strong = flanked_range('*')
+lex:add_rule('strong', lex:tag(lexer.BOLD, asterisk_strong))
+
+local underscore_em = (B(punct_space) + #lexer.starts_line('_')) * flanked_range('_', true) *
+	#(punct_space + -1)
+lex:add_rule('em', lex:tag(lexer.ITALIC, underscore_em))
+
+-- TODO: Bold with Italic doesn't work, but it doesn't on the site either
+-- https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#text-formatting
+
+local attribute = flanked_range(':')
+lex:add_rule('attribute', lex:tag(lexer.ATTRIBUTE, attribute))
+
+-- Comments.
+lex:add_rule('comment', lex:tag(lexer.COMMENT,
+	lexer.range(lexer.starts_line('////')) +
+	lexer.starts_line(lexer.to_eol('//'))))
+
+lexer.property['scintillua.comment'] = '//'
+
+return lex

--- a/lexers/asciidoc.lua
+++ b/lexers/asciidoc.lua
@@ -13,16 +13,19 @@ local lex = lexer.new(...)
 
 -- Admonitions.
 lex:add_rule('admonition', lex:tag(lexer.KEYWORD, lex:word_match(lexer.KEYWORD) * #S(':')))
-lex:add_rule('block_admonition', lex:tag(lexer.KEYWORD, P('[') * lex:word_match(lexer.KEYWORD) * P(']')))
+lex:add_rule('block_admonition',
+	lex:tag(lexer.KEYWORD, P('[') * lex:word_match(lexer.KEYWORD) * P(']')))
 lex:set_word_list(lexer.KEYWORD, {"NOTE", "IMPORTANT", "WARNING", "TIP", "CAUTION", "TESTME"})
 
 -- Block elements.
 local function h(n)
 	return lex:tag(string.format('%s.h%s', lexer.HEADING, n),
-		lexer.to_eol(lexer.starts_line(string.rep('=', n))))
+		lexer.to_eol(lexer.starts_line((string.rep('=', n) * S(' ') * lexer.alnum)) +
+			string.rep('#', n) * S(' ') * lexer.alnum))
 end
 lex:add_rule('header', h(6) + h(5) + h(4) + h(3) + h(2) + h(1))
-lex:add_rule('block_title', lex:tag(lexer.HEADING, lexer.to_eol(lexer.starts_line('.') * lexer.alnum)))
+lex:add_rule('block_title',
+	lex:tag(lexer.HEADING, lexer.to_eol(lexer.starts_line('.') * lexer.alnum)))
 
 lex:add_rule('hr',
 	lex:tag('hr', lpeg.Cmt(lexer.starts_line(lpeg.C(S("*-'")), true), function(input, index, c)
@@ -31,8 +34,7 @@ lex:add_rule('hr',
 		return (select(2, input:find('\r?\n', index)) or #input) + 1 -- include \n for eolfilled styles
 	end)))
 
-lex:add_rule('list', lex:tag(lexer.LIST,
-	lexer.starts_line(S('*.')^1, true) * S(' \t')))
+lex:add_rule('list', lex:tag(lexer.LIST, lexer.starts_line(S('*.')^1, true) * S(' \t')))
 
 -- Span elements.
 lex:add_rule('escape', lex:tag(lexer.DEFAULT, P('\\') * 1))
@@ -80,15 +82,11 @@ local underscore_em = (B(punct_space) + #lexer.starts_line('_')) * flanked_range
 	#(punct_space + -1)
 lex:add_rule('em', lex:tag(lexer.ITALIC, underscore_em))
 
--- TODO: Bold with Italic doesn't work, but it doesn't on the site either
--- https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#text-formatting
-
 local attribute = flanked_range(':')
 lex:add_rule('attribute', lex:tag(lexer.ATTRIBUTE, attribute))
 
 -- Comments.
-lex:add_rule('comment', lex:tag(lexer.COMMENT,
-	lexer.range(lexer.starts_line('////')) +
+lex:add_rule('comment', lex:tag(lexer.COMMENT, lexer.range(lexer.starts_line('////')) +
 	lexer.starts_line(lexer.to_eol('//'))))
 
 lexer.property['scintillua.comment'] = '//'


### PR DESCRIPTION
Picking up from #151

Marking as WIP because it still needs work, but opening an avenue for feedback.
So far:

- Correct heading rule as Asciidoc uses `=` instead of `#`
- Add [Optional Title rule](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#more-delimited-blocks)
- Change strong/em rules as they are not the same as Markdown, changed code rules to be a 'monospace' rule
- Remove HTML embedding as Asciidoc is its own thing, not a HTML superset like Markdown 
- Improve Admonitions as the keywords should only be highlighted in certain scenarios
- Correct [list rule](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#lists)
- Correct Horizontal Rule rule (Asciidoc uses `'''`)

There is the question of whether Asciidoc's (very limited) [Markdown compatibility](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#markdown-compatibility) should be implemented. Not all implementations of Asciidoc support this. At the moment I have kept that compatibility in the Horizontal Rule rule but I am tempted to remove it.

Also mentioning #104  
