### PR TITLE
Improve Perl heredoc lexing

### DIFF
--- a/lexers/perl.lua
+++ b/lexers/perl.lua
@@ -56,7 +56,7 @@ local sq_str = lexer.range("'")
 local dq_str = lexer.range('"')
 local cmd_str = lexer.range('`')
 local heredoc = '<<' * P(function(input, index)
-	local s, e, indented, _, delimiter = input:find('(~?)(["\'`]?)([%a_][%w_]*)%2[\n\r\f;]+', index)
+	local s, e, indented, _, delimiter = input:find('(~?)(["\'`]?)([%a_][%w_]*)%2.-[\r\n]+', index)
 	if s == index and delimiter then
 		local end_heredoc = (#indented > 0 and '[\n\r\f]+ *' or '[\n\r\f]+')
 		e = select(2, input:find(end_heredoc .. delimiter, e))


### PR DESCRIPTION
This PR changes the behavior of the Perl heredoc lexer to accept heredocs anywhere on a line, rather than exclusively at the end of a line/statement.