### PR TITLE
C: Move enum to type keyword list

### DIFF
--- a/lexers/c.lua
+++ b/lexers/c.lua
@@ -71,7 +71,7 @@ lex:add_fold_point(lexer.COMMENT, '/*', '*/')
 
 -- Word lists.
 lex:set_word_list(lexer.KEYWORD, {
-	'auto', 'break', 'case', 'const', 'continue', 'default', 'do', 'else', 'enum', 'extern', 'for',
+	'auto', 'break', 'case', 'const', 'continue', 'default', 'do', 'else', 'extern', 'for',
 	'goto', 'if', 'inline', 'register', 'restrict', 'return', 'sizeof', 'static', 'switch', 'typedef',
 	'volatile', 'while', --
 	'false', 'true', -- C99
@@ -81,7 +81,7 @@ lex:set_word_list(lexer.KEYWORD, {
 })
 
 lex:set_word_list(lexer.TYPE, {
-	'bool', 'char', 'double', 'float', 'int', 'long', 'short', 'signed', 'struct', 'union',
+	'bool', 'char', 'double', 'float', 'int', 'long', 'short', 'signed', 'struct', 'union', 'enum',
 	'unsigned', 'void', --
 	'complex', 'imaginary', '_Complex', '_Imaginary', -- complex.h C99
 	'lconv', -- locale.h


### PR DESCRIPTION
This PR moves `enum` to the type keyword list as opposed to the normal keyword list. This is because I believe `enum` has more in common with compound type keywords like `struct` or `union` than other normal keywords. As an example, the `enum` type in the screenshot below would be green instead of yellow, which would be more consistent with the other compound types.

<img width="355" height="227" alt="Screenshot_2026-06-26_09-47-29" src="https://github.com/user-attachments/assets/057d964c-7725-4b1e-b168-730a8d715b64" />

What are your thoughts on this?  I understand this might be more of a case of personal taste.